### PR TITLE
Create a Scalatest tag for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ Whereas the same object typed as a PayPalReferenceTransaction will serialise to:
 As a result of this we need to decode back to the exact type which we encoded from or we will a get a decoding failure.
 
 This behaviour is illustrated through a number of tests in [CirceEncodingBehaviourSpec.](/monthly-contributions/src/test/scala/com/gu/support/workers/CirceEncodingBehaviourSpec.scala) 
+
+## Tests 
+There are a number of integration tests in the project which talk to real services, these are useful for real end to end testing, but slow to run and prone to failures if any of the services are playing up.
+
+These tests are tagged with either an @IntegrationTest annotation at the spec level or an IntegrationTest tag at the individual test level which allows us to run them selectively as follows: 
+
+`sbt test` - runs all tests including integration tests.
+
+`sbt testOnly -- -l com.gu.test.tags.annotations.IntegrationTest` - runs non-integration tests only. 

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ lazy val scalaStyleSettings = Seq(
 
 lazy val root =
   project.in(file("."))
+    .settings(
+      name := "support-workers"
+    )
     .aggregate(common, `monthly-contributions`)
 
 lazy val common = project

--- a/common/src/main/scala/com/gu/helpers/WebServiceHelper.scala
+++ b/common/src/main/scala/com/gu/helpers/WebServiceHelper.scala
@@ -54,7 +54,6 @@ trait WebServiceHelper[Error <: Throwable] extends LazyLogging {
       response <- httpClient(req)
     } yield {
       val responseBody = response.body.string()
-      logger.debug(s"$responseBody")
       decode[A](responseBody) match {
         case Left(err) => throw decode[Error](responseBody).right.getOrElse(
           WebServiceHelperError[A](response.code(), responseBody)

--- a/common/src/test/java/com/gu/test/tags/annotations/IntegrationTest.java
+++ b/common/src/test/java/com/gu/test/tags/annotations/IntegrationTest.java
@@ -1,0 +1,15 @@
+package com.gu.test.tags.annotations;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface IntegrationTest {
+}
+

--- a/common/src/test/scala/com.gu.config/ConfigSpec.scala
+++ b/common/src/test/scala/com.gu.config/ConfigSpec.scala
@@ -9,12 +9,10 @@ class ConfigSpec extends FlatSpec with Matchers with LazyLogging {
     Configuration.stage should be(Stages.DEV)
 
     val s = Configuration.stripeConfig
-    logger.debug(s"Output: $s")
     s.publicKey should be("pk_test_Qm3CGRdrV4WfGYCpm0sftR0f")
     s.secretKey.length should be > 0
 
     val p = Configuration.payPalConfig
-    logger.debug(s"Output: $p")
     p.NVPVersion should be("124.0")
     p.signature.length should be > 0
 

--- a/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -4,19 +4,20 @@ import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
 import com.gu.salesforce.Fixtures._
 import com.gu.salesforce.Salesforce.{Authentication, SalesforceContactResponse, UpsertData}
+import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
+@IntegrationTest
 class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "AuthService" should "be able to retrieve an authtoken" in {
     val authService = new AuthService(Configuration.salesforceConfig, RequestRunners.configurableFutureRunner(10.seconds))
 
     authService.authorize.map { auth =>
-      logger.info(s"Retrieved auth token $auth")
       auth.access_token.length should be > 0
     }
   }
@@ -40,7 +41,6 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     val upsertData = UpsertData.create(idId, email, name, name, allowMail, allowMail, allowMail)
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
-      logger.info(s"Retrieved contact id $response")
       response.Success should be(true)
       response.ContactRecord.Id should be(salesforceId)
     }

--- a/common/src/test/scala/com/gu/test/tags/objects/IntegrationTest.scala
+++ b/common/src/test/scala/com/gu/test/tags/objects/IntegrationTest.scala
@@ -1,0 +1,5 @@
+package com.gu.test.tags.objects
+
+import org.scalatest.Tag
+
+case object IntegrationTest extends Tag("com.gu.test.tags.annotations.IntegrationTest")

--- a/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
@@ -4,7 +4,6 @@ import com.gu.zuora.Fixtures._
 import com.gu.zuora.encoding.CustomCodecs._
 import com.gu.zuora.model._
 import com.typesafe.scalalogging.LazyLogging
-import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
@@ -20,14 +19,12 @@ class SerialisationSpec extends FlatSpec with Matchers with LazyLogging  {
 
   "PaymentMethod" should "serialise to correct json" in {
     val json = creditCardPaymentMethod.asJson
-    logger.info(json.spaces2)
   }
 
   "SubscribeRequest" should "serialise to correct json" in {
     val json = subscriptionRequest.asJson
     (json \\ "GenerateInvoice").head.asBoolean should be(Some(true))
     (json \\ "sfContactId__c").head.asString.get should be (salesforceId)
-    logger.info(json.pretty(Printer.spaces2.copy(dropNullKeys = true)))
   }
 
   "InvoiceResult" should "deserialise correctly" in {

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -2,12 +2,14 @@ package com.gu.zuora
 
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
+import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures.subscriptionRequest
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
+@IntegrationTest
 class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "ZuoraService" should "retrieve an account" in {
@@ -23,7 +25,6 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     val zuoraService = new ZuoraService(Configuration.zuoraConfig, RequestRunners.configurableFutureRunner(30.seconds))
     zuoraService.subscribe(subscriptionRequest).map {
       response =>
-        logger.info(s"$response")
         response.head.success should be(true)
     }
   }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/CreatePaymentMethodStateDecoder.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/CreatePaymentMethodStateDecoder.scala
@@ -41,7 +41,6 @@ object CreatePaymentMethodStateDecoder extends LazyLogging {
           amount <- decodeBigDecimal.decodeJson(amountJson)
           paymentFields <- decodePaymentFields.decodeJson(paymentFieldsJson)
         } yield {
-          logger.info(s"$user, $amount, $paymentFields")
           CreatePaymentMethodState(user, amount, paymentFields)
         }
       }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CirceEncodingBehaviourSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CirceEncodingBehaviourSpec.scala
@@ -34,7 +34,7 @@ class CirceEncodingBehaviourSpec extends FlatSpec with Matchers with LazyLogging
   "Circe" should "be able to decode PaymentMethod from PaymentMethod" in {
     val pprt: PaymentMethod = PayPalReferenceTransaction("123", "test@test.com")
     val json = pprt.asJson
-    logger.info(json.spaces2)
+    //logger.info(json.spaces2)
     /*
     {
       "PayPalReferenceTransaction" : {
@@ -52,7 +52,7 @@ class CirceEncodingBehaviourSpec extends FlatSpec with Matchers with LazyLogging
   it should "be able to decode PayPalReferenceTransaction from PayPalReferenceTransaction" in {
     val pprt = PayPalReferenceTransaction("123", "test@test.com")
     val json = pprt.asJson
-    logger.info(json.spaces2)
+    //logger.info(json.spaces2)
     /*
     {
       "baId" : "123",
@@ -66,7 +66,6 @@ class CirceEncodingBehaviourSpec extends FlatSpec with Matchers with LazyLogging
   it should "fail to decode PayPalReferenceTransaction from PaymentMethod" in {
     val pprt: PaymentMethod = PayPalReferenceTransaction("123", "test@test.com")
     val json = pprt.asJson
-    logger.info(json.noSpaces)
     val pprt2 = decode[PayPalReferenceTransaction](json.noSpaces)
     pprt2.isLeft should be(true) //decoding failed
   }
@@ -74,7 +73,6 @@ class CirceEncodingBehaviourSpec extends FlatSpec with Matchers with LazyLogging
   it should "fail to decode PaymentMethod from PayPalReferenceTransaction" in {
     val pprt = PayPalReferenceTransaction("123", "test@test.com")
     val json = pprt.asJson
-    logger.info(json.noSpaces)
     val pprt2 = decode[PaymentMethod](json.noSpaces)
     pprt2.isLeft should be(true) //decoding failed
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodSpec.scala
@@ -9,6 +9,7 @@ import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamCo
 import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.lambdas.CreatePaymentMethod
 import com.gu.support.workers.model.CreateSalesforceContactState
+import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.model.{CreditCardReferenceTransaction, PayPalReferenceTransaction, PaymentMethod}
 import io.circe.ParsingFailure
 import io.circe.generic.auto._
@@ -18,6 +19,7 @@ import org.mockito.Mockito._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@IntegrationTest
 class CreatePaymentMethodSpec extends LambdaSpec {
 
   "CreatePaymentMethod" should "retrieve a valid PayPalReferenceTransaction when given a valid baid" in {
@@ -33,7 +35,6 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     outStream.toClass[CreateSalesforceContactState]() match {
       case state@CreateSalesforceContactState(_, _, payPal: PayPalReferenceTransaction) =>
-        logger.info(s"$state")
         payPal.paypalBaid should be(validBaid)
         payPal.paypalEmail should be("membership.paypal-buyer@theguardian.com")
       case _ => fail()
@@ -69,7 +70,6 @@ class CreatePaymentMethodSpec extends LambdaSpec {
       createPaymentMethod.handleRequest(inStream, outStream, mock[Context])
 
       val p = outStream.toClass[PaymentMethod]()
-      logger.info(s"Output: $p")
     }
   }
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactDecoderSpec.scala
@@ -32,7 +32,6 @@ class CreateSalesforceContactDecoderSpec  extends FlatSpec with Matchers with Mo
 
   "Decoder" should "be able to decode PaymentMethod" in {
     val result = decode[PaymentMethod](payPalPaymentMethod)
-    logger.info(s"$result")
     result.isRight should be (true)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactSpec.scala
@@ -7,8 +7,10 @@ import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamCo
 import com.gu.support.workers.Fixtures.createSalesForceContactJson
 import com.gu.support.workers.lambdas.CreateSalesforceContact
 import com.gu.support.workers.model.CreateZuoraSubscriptionState
+import com.gu.test.tags.annotations.IntegrationTest
 import io.circe.generic.auto._
 
+@IntegrationTest
 class CreateSalesforceContactSpec extends LambdaSpec {
 
   "CreateSalesForceContact lambda" should "retrieve a SalesforceContactRecord" in {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
@@ -7,13 +7,13 @@ import com.gu.okhttp.RequestRunners
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures._
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
-import com.gu.support.workers.model.SendThankYouEmailState
 import com.gu.zuora.ZuoraService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import io.circe.generic.auto._
 
+@IntegrationTest
 class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
   "CreateZuoraSubscription lambda" should "create a Zuora subscription" in {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
@@ -7,11 +7,13 @@ import com.gu.okhttp.RequestRunners
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures._
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
+import com.gu.support.workers.model.SendThankYouEmailState
+import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.ZuoraService
+import io.circe.generic.auto._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import io.circe.generic.auto._
 
 @IntegrationTest
 class CreateZuoraSubscriptionSpec extends LambdaSpec {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/SendThankYouEmailSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/SendThankYouEmailSpec.scala
@@ -1,10 +1,13 @@
 package com.gu.support.workers
 
 import java.io.ByteArrayOutputStream
+
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures.thankYouEmailJson
 import com.gu.support.workers.lambdas.SendThankYouEmail
+import com.gu.test.tags.annotations.IntegrationTest
 
+@IntegrationTest
 class SendThankYouEmailSpec extends LambdaSpec {
 
   "SendThankYouEmail lambda" should "add message to sqs queue" in {
@@ -14,6 +17,6 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
     sendThankYouEmail.handleRequest(thankYouEmailJson.asInputStream(), outStream, context)
 
-    outStream.toClass[Unit]() shouldEqual (())
+    outStream.toClass[Unit]() shouldEqual ()
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val stm = "org.scala-stm" %% "scala-stm" % "0.8"
 
-  val commonDependencies: Seq[ModuleID] = Seq(config, logback, scalaLogging, akkaAgent, joda, dispatch,
+  val commonDependencies: Seq[ModuleID] = Seq(config, logback, scalaLogging, joda, dispatch,
     supportInternationalisation, awsCloudwatch, awsS3, awsSQS, awsLambdas, okhttp, scalaUri, cats, circeCore,
     circeGeneric, circeGenericExtras, circeParser, stm, scalaTest)
   val monthlyContributionsDependencies: Seq[ModuleID] = Seq(mokito, scalaTest)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -8,8 +8,6 @@ object Settings {
     version := appVersion,
     organization := "com.gu",
     scalaVersion := "2.11.8",
-    scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings"),
-    //Don't run tests marked as integration tests
-    testOptions in Test += Tests.Argument("-l", "com.gu.test.tags.annotations.IntegrationTest")
+    scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
   )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -8,6 +8,8 @@ object Settings {
     version := appVersion,
     organization := "com.gu",
     scalaVersion := "2.11.8",
-    scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+    scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings"),
+    //Don't run tests marked as integration tests
+    testOptions in Test += Tests.Argument("-l", "com.gu.test.tags.annotations.IntegrationTest")
   )
 }


### PR DESCRIPTION
There are a number of integration tests in the project which talk to real services, these are very useful for real end to end testing, but slow to run and prone to failures if any of the services are playing up.

This PR adds a ScalaTest tag and annotation 'IntegrationTest' which can be applied to individual tests (the tag) or whole specs (the annotation) to stop them running when the sbt test command is invoked; it also tags the appropriate tests/specs with these tags.