### PR TITLE
Replace the scheduled Salesforce Auth token fetch

### DIFF
--- a/common/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/common/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -1,5 +1,7 @@
 package com.gu.salesforce
 
+import org.joda.time.DateTime
+
 object Salesforce {
 
   object UpsertData {
@@ -44,6 +46,9 @@ object Salesforce {
 
   case class SalesforceErrorResponse(Success: Boolean, ErrorString: Option[String]) extends Throwable with SalesforceResponse
 
-  case class Authentication(access_token: String, instance_url: String)
+  case class Authentication(access_token: String, instance_url: String, issued_at: DateTime){
+    private val expiryTimeMinutes = 15
+    def isStale: Boolean = issued_at.isBefore(DateTime.now().minusMinutes(expiryTimeMinutes))
+  }
 
 }

--- a/common/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/common/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -55,8 +55,9 @@ object AuthService extends LazyLogging {
   def getAuth: Future[Authentication] = authRef.single() match {
     case Some(authentication) =>
       if (authentication.isStale)
-        fetchAuth //Fetch a new auth token but return the one we currently have
-      Future.successful(authentication)
+        fetchAuth
+      else
+        Future.successful(authentication)
     case None => fetchAuth
   }
 

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -5,7 +5,7 @@ import com.gu.i18n.{Country, Currency}
 import com.gu.zuora.encoding.CapitalizationEncoder._
 import com.gu.zuora.model._
 import io.circe._
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, LocalDate}
 
 object CustomCodecs extends CustomCodecs
 
@@ -49,6 +49,7 @@ trait CustomCodecs {
 
   //Encode joda LocalDate to the format expected by Zuora
   implicit val encodeLocalTime: Encoder[LocalDate] = Encoder.encodeString.contramap[LocalDate](_.toString("yyyy-MM-dd"))
+  implicit val decodeDateTime: Decoder[DateTime] = Decoder.decodeLong.map(new DateTime(_))
 
   //response decoders
   implicit val decodeInvoice: Decoder[Invoice] = decapitalizingDecoder[Invoice]

--- a/common/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/common/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -18,4 +18,15 @@ object Fixtures {
          "Allow_Guardian_Related_Mail__c": $allowMail
        }
       }"""
+  val authJson =
+    """
+      {
+        "access_token": "00Dg0000006RDAM!AREAQKDFKQ.ZPdIxWp4Z55tyVgs0D_kPhaiCMndEOk7WVB8yRffLVNK9TFbtZk34cWAfaaeojHL2ndURQounCzhRfBE_nMct",
+        "instance_url": "https://cs17.salesforce.com",
+        "id": "https://test.salesforce.com/id/00Dg0000006RDAMEA4/00520000003DLCDAA4",
+        "token_type": "Bearer",
+        "issued_at": "%d",
+        "signature": "UK0fYmoyyuefxqsXFnovXy/RM/MleImPqZcf72ax+As="
+      }
+    """
 }

--- a/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -1,16 +1,33 @@
 package com.gu.salesforce
 
+import com.gu.salesforce.Fixtures._
+import com.gu.salesforce.Salesforce.{Authentication, NewContact, UpsertData}
+import com.gu.zuora.encoding.CustomCodecs
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.{FlatSpec, Matchers}
-import io.circe.syntax._
 import io.circe.generic.auto._
 import io.circe.parser._
-import Fixtures._
-import com.gu.salesforce.Salesforce.{NewContact, UpsertData}
+import io.circe.syntax._
+import org.joda.time.DateTime
+import org.scalatest.{FlatSpec, Matchers}
 
-class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
+class SerialisationSpec extends FlatSpec with Matchers with LazyLogging with CustomCodecs {
   "UpsertData" should "serialise to correct json" in {
     val upsertData = UpsertData(NewContact(idId, email, name, name, allowMail, allowMail, allowMail))
     upsertData.asJson should be(parse(upsertJson).right.get)
+  }
+
+  "Authentication" should "deserialize correctly" in {
+    val now = DateTime.now()
+    val stale = DateTime.parse("1971-02-20")
+
+    //Deserialize a fresh token
+    val decodeResult = decode[Authentication](authJson.format(now.getMillis)) //issued_at time is in millis
+    decodeResult.isRight should be(true)
+    decodeResult.right.get.isStale should be(false)
+
+    //Deserialize a stale token
+    val decodeResult2 = decode[Authentication](authJson.format(stale.getMillis))
+    decodeResult2.isRight should be(true)
+    decodeResult2.right.get.isStale should be(true)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,12 +22,11 @@ object Dependencies {
   val circeGenericExtras = "io.circe" %% "circe-generic-extras" % circeVersion
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
-  //Used for retrying http requests
-  val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4" //Used by the Salesforce code for handling auth tokens
+  val stm = "org.scala-stm" %% "scala-stm" % "0.8"
 
   val commonDependencies: Seq[ModuleID] = Seq(config, logback, scalaLogging, akkaAgent, joda, dispatch,
     supportInternationalisation, awsCloudwatch, awsS3, awsSQS, awsLambdas, okhttp, scalaUri, cats, circeCore,
-    circeGeneric, circeGenericExtras, circeParser, scalaTest)
+    circeGeneric, circeGenericExtras, circeParser, stm, scalaTest)
   val monthlyContributionsDependencies: Seq[ModuleID] = Seq(mokito, scalaTest)
 
 }


### PR DESCRIPTION
Instead use the issued_at time of the token to check whether we should refresh it or not.

This simplifies the logic and also allows us to remove Akka from the project. 

To handle the concurrency & mutable state I'm using [ScalaSTM](https://nbronson.github.io/scala-stm/) which is really nice.