### PR TITLE
Only log as error in the top level handler to avoid flooding Sentry

### DIFF
--- a/common/src/main/scala/com.gu.okhttp/package.scala
+++ b/common/src/main/scala/com.gu.okhttp/package.scala
@@ -17,7 +17,7 @@ package object okhttp {
       client.newCall(request).enqueue(new Callback {
         override def onFailure(call: Call, e: IOException) {
           val sanitizedUrl = s"${request.url().uri().getHost}${request.url().uri().getPath}" // don't log query string
-          logger.error(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
+          logger.warn(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
           p.failure(e)
         }
 

--- a/common/src/main/scala/com/gu/helpers/Retry.scala
+++ b/common/src/main/scala/com/gu/helpers/Retry.scala
@@ -1,16 +1,16 @@
 package com.gu.helpers
 
+import com.typesafe.scalalogging.LazyLogging
+import dispatch.Defaults.timer
+import dispatch.{retry, _}
+
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Failure
-import scala.concurrent.duration._
-import dispatch._
-import Defaults.timer
-import com.typesafe.scalalogging.LazyLogging
-import dispatch.retry
 
 object Retry extends LazyLogging {
   def apply[A](count: Int, errMsg: String = "Error despite retrying: ")(request: => Future[A])(implicit ec: ExecutionContext): Future[A] =
     retry.Backoff(max = count, delay = 2.seconds, base = 2) { () =>
       request.either
-    } flatMap (_.fold(Future.failed, Future.successful)) andThen { case Failure(e) => logger.error(errMsg, e) }
+    } flatMap (_.fold(Future.failed, Future.successful)) andThen { case Failure(e) => logger.warn(errMsg, e) }
 }

--- a/common/src/main/scala/com/gu/paypal/PayPalService.scala
+++ b/common/src/main/scala/com/gu/paypal/PayPalService.scala
@@ -32,8 +32,8 @@ class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) extends L
     retrieveNVPParam(response, "ACK") match {
       case "Success" => logger.info("Successful PayPal NVP request")
       case "SuccessWithWarning" => logger.warn(msg("Warning"))
-      case "Failure" => logger.error(msg("Error"))
-      case "FailureWithWarning" => logger.error(msg("Error With Warning"))
+      case "Failure" => logger.warn(msg("Error"))
+      case "FailureWithWarning" => logger.warn(msg("Error With Warning"))
     }
 
   }

--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -9,12 +9,12 @@ object Stripe {
 
   sealed trait StripeObject
 
-  object Error {
-    implicit val codec: Codec[Error] = deriveCodec
+  object StripeError {
+    implicit val codec: Codec[StripeError] = deriveCodec
   }
 
   //See docs here: https://stripe.com/docs/api/curl#errors
-  case class Error(
+  case class StripeError(
     `type`: String, //The type of error: api_connection_error, api_error, authentication_error, card_error, invalid_request_error, or rate_limit_error
     message: String, //A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
     code: String = "", //For card errors, a short string from amongst those listed on the right describing the kind of card error that occurred.
@@ -52,7 +52,7 @@ object Stripe {
   case class Customer(id: String, cards: StripeList[Card]) extends StripeObject {
     // customers should always have a card
     if (cards.total_count != 1) {
-      throw Error("internal", s"Customer $id has ${cards.total_count} cards, should have exactly one")
+      throw StripeError("internal", s"Customer $id has ${cards.total_count} cards, should have exactly one")
     }
 
     val card = cards.data.head

--- a/common/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/common/src/main/scala/com/gu/stripe/StripeService.scala
@@ -8,7 +8,7 @@ import okhttp3.Request
 import scala.concurrent.{ExecutionContext, Future}
 
 class StripeService(config: StripeConfig, client: FutureHttpClient, baseUrl: String = "https://api.stripe.com/v1")(implicit ec: ExecutionContext)
-    extends WebServiceHelper[Stripe.Error] {
+    extends WebServiceHelper[Stripe.StripeError] {
 
   // Stripe URL is the same in all environments
   val wsUrl = baseUrl

--- a/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -6,25 +6,31 @@ import com.gu.salesforce.Salesforce.SalesforceErrorResponse
 import com.gu.stripe.Stripe
 import com.gu.support.workers.exceptions.RetryImplicits._
 import com.gu.zuora.model.ZuoraErrorResponse
+import com.typesafe.scalalogging.LazyLogging
 
 /**
  * Maps exceptions from the application to either fatal or non fatal exceptions
  * based on whether we think retrying them has a chance of succeeding
  * see support-workers/docs/error-handling.md
  */
-object ErrorHandler {
+object ErrorHandler extends LazyLogging {
   val handleException: PartialFunction[Throwable, Any] = {
-    //Stripe
-    case e: Stripe.Error => throw e.asRetryException
-    //PayPal
-    case e: PayPalError => throw e.asRetryException
-    //AWS encryption SDK
-    case e: AWSKMSException => throw e.asRetryException
-    //Zuora
-    case e: ZuoraErrorResponse => throw e.asRetryException
-    //Salesforce
-    case e: SalesforceErrorResponse => throw e.asRetryException
-    //Any Exception that we haven't specifically handled
-    case e: Throwable => throw e.asRetryException
+      //Stripe
+      case e: Stripe.StripeError => logAndRethrow(e.asRetryException)
+      //PayPal
+      case e: PayPalError => logAndRethrow(e.asRetryException)
+      //AWS encryption SDK
+      case e: AWSKMSException => logAndRethrow(e.asRetryException)
+      //Zuora
+      case e: ZuoraErrorResponse => logAndRethrow(e.asRetryException)
+      //Salesforce
+      case e: SalesforceErrorResponse => logAndRethrow(e.asRetryException)
+      //Any Exception that we haven't specifically handled
+      case e: Throwable => logAndRethrow(e.asRetryException)
+    }
+
+  def logAndRethrow(t: RetryException): Unit = {
+    logger.error(s"${t.getMessage}", t)
+    throw t
   }
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -3,10 +3,11 @@ package com.gu.support.workers.lambdas
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.salesforce.Salesforce.UpsertData
 import com.gu.services.Services
+import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.exceptions.SalesforceException
 import com.gu.support.workers.model.state.{CreateSalesforceContactState, CreateZuoraSubscriptionState}
 import com.typesafe.scalalogging.LazyLogging
-import com.gu.support.workers.encoding.StateCodecs._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactState, CreateZuoraSubscriptionState] with LazyLogging {
@@ -26,7 +27,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
         CreateZuoraSubscriptionState(state.requestId, state.user, state.contribution, state.paymentMethod, response.ContactRecord)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
-        logger.error(s"Error creating Salesforce contact:\n$errorMessage")
+        logger.warn(s"Error creating Salesforce contact:\n$errorMessage")
         throw new SalesforceException(errorMessage)
       })
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -47,10 +47,10 @@ class ErrorHandlerSpec extends FlatSpec with Matchers {
     new SalesforceErrorResponse("", "").asRetryException shouldBe a[RetryNone]
 
     //Stripe
-    new Stripe.Error("card_error", "").asRetryException shouldBe a[RetryNone]
-    new Stripe.Error("invalid_request_error", "").asRetryException shouldBe a[RetryNone]
-    new Stripe.Error("api_error", "").asRetryException shouldBe a[RetryUnlimited]
-    new Stripe.Error("rate_limit_error", "").asRetryException shouldBe a[RetryUnlimited]
+    new Stripe.StripeError("card_error", "").asRetryException shouldBe a[RetryNone]
+    new Stripe.StripeError("invalid_request_error", "").asRetryException shouldBe a[RetryNone]
+    new Stripe.StripeError("api_error", "").asRetryException shouldBe a[RetryUnlimited]
+    new Stripe.StripeError("rate_limit_error", "").asRetryException shouldBe a[RetryUnlimited]
 
     //PayPal
     PayPalError(500, "").asRetryException shouldBe a[RetryUnlimited]

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -45,7 +45,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
   }
 
   "402s from Stripe" should "throw a FatalException" in {
-    val errorJson = Stripe.Error("card_error", "The card has expired", "expired_card").asJson.noSpaces
+    val errorJson = Stripe.StripeError("card_error", "The card has expired", "expired_card").asJson.noSpaces
     val server = createMockServer(402, errorJson)
     val baseUrl = server.url("/v1")
 


### PR DESCRIPTION
Log errors as warnings elsewhere.

Also renamed Stripe.Error to StripeError as it is clearer in Sentry