### PR TITLE
Failure handler

### DIFF
--- a/cloud-formation/src/lambdas/failureHandlerLambda.yaml
+++ b/cloud-formation/src/lambdas/failureHandlerLambda.yaml
@@ -1,0 +1,14 @@
+FailureHandlerLambda:
+  Type: "AWS::Lambda::Function"
+  Description: "Failure handler"
+  Properties:
+    $environment_variables
+    FunctionName: !Sub ${Stack}-FailureHandlerLambda-${Stage}
+    Handler: "com.gu.support.workers.lambdas.FailureHandlerLambda::handleRequest"
+    MemorySize: 256
+    Role: !GetAtt [ LambdaExecutionRole, Arn ]
+    Code:
+      S3Bucket: support-workers-dist
+      S3Key: lambdas/bin/guardian-support-monthly-contributions-lambdas-assembly-0.1-SNAPSHOT.jar
+    Runtime: "java8"
+    Timeout: "60"

--- a/cloud-formation/src/state-machine-retries.yaml
+++ b/cloud-formation/src/state-machine-retries.yaml
@@ -11,4 +11,5 @@ Retry:
     Catch:
       ErrorEquals:
       - States.All
+      ResultPath: "$.error"
       Next: FailureHandler

--- a/cloud-formation/src/state-machine-retries.yaml
+++ b/cloud-formation/src/state-machine-retries.yaml
@@ -8,3 +8,7 @@ Retry:
       - com.gu.support.workers.exceptions.RetryUnlimited
       IntervalSeconds: 1
       BackoffRate: 2
+    Catch:
+      ErrorEquals:
+      - States.All
+      Next: FailureHandler

--- a/cloud-formation/src/state-machine.yaml
+++ b/cloud-formation/src/state-machine.yaml
@@ -20,7 +20,16 @@ States:
     Type: Task
     Resource: "${SendThankYouEmailLambda.Arn}"
     End: True
-    $state_machine_retries
+    Retry:
+    - ErrorEquals:
+      - com.gu.support.workers.exceptions.RetryLimited
+      IntervalSeconds: 1
+      MaxAttempts: 3
+      BackoffRate: 2
+    - ErrorEquals:
+      - com.gu.support.workers.exceptions.RetryUnlimited
+      IntervalSeconds: 1
+      BackoffRate: 2
   FailureHandler:
     Type: Task
     Resource: "${FailureHandlerLambda.Arn}"

--- a/cloud-formation/src/state-machine.yaml
+++ b/cloud-formation/src/state-machine.yaml
@@ -20,7 +20,7 @@ States:
     Type: Task
     Resource: "${SendThankYouEmailLambda.Arn}"
     End: True
-    Retry:
+    Retry: # We don't want to invoke the failure handler for the thank you email because signup has succeeded by this point
     - ErrorEquals:
       - com.gu.support.workers.exceptions.RetryLimited
       IntervalSeconds: 1

--- a/cloud-formation/src/state-machine.yaml
+++ b/cloud-formation/src/state-machine.yaml
@@ -4,20 +4,24 @@ States:
   CreatePaymentMethod:
     Type: Task
     Resource: "${CreatePaymentMethodLambda.Arn}"
-    $state_machine_retries
     Next: CreateSalesforceContact
+    $state_machine_retries
   CreateSalesforceContact:
     Type: Task
     Resource: "${CreateSalesforceContactLambda.Arn}"
-    $state_machine_retries
     Next: CreateZuoraSubscription
+    $state_machine_retries
   CreateZuoraSubscription:
     Type: Task
     Resource: "${CreateZuoraSubscriptionLambda.Arn}"
-    $state_machine_retries
     Next: SendThankYouEmail
+    $state_machine_retries
   SendThankYouEmail:
     Type: Task
     Resource: "${SendThankYouEmailLambda.Arn}"
+    End: True
     $state_machine_retries
+  FailureHandler:
+    Type: Task
+    Resource: "${FailureHandlerLambda.Arn}"
     End: True

--- a/common/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -9,30 +9,30 @@ import org.joda.time.DateTime
 import scala.concurrent.Future
 
 case class EmailFields(
-    email: String,
-    created: DateTime,
-    amount: BigDecimal,
-    currency: String,
-    edition: String,
-    name: String
+  email: String,
+  created: DateTime,
+  amount: BigDecimal,
+  currency: String,
+  edition: String,
+  name: String
 ) {
   def payload(dataExtensionName: String): String =
     s"""
-      |{
-      |  "To": {
-      |    "Address": "$email",
-      |    "SubscriberKey": "$email",
-      |    "ContactAttributes": {
-      |      "EmailAddress": "$email",
-      |      "created": "$created",
-      |      "amount": $amount,
-      |      "currency": "$currency",
-      |      "edition": "$edition",
-      |      "name": "$name"
-      |    }
-      |  },
-      |  "DataExtensionName": "$dataExtensionName"
-      |}
+       |{
+       |  "To": {
+       |    "Address": "$email",
+       |    "SubscriberKey": "$email",
+       |    "ContactAttributes": {
+       |      "EmailAddress": "$email",
+       |      "created": "$created",
+       |      "amount": $amount,
+       |      "currency": "$currency",
+       |      "edition": "$edition",
+       |      "name": "$name"
+       |    }
+       |  },
+       |  "DataExtensionName": "$dataExtensionName"
+       |}
     """.stripMargin
 }
 
@@ -47,6 +47,5 @@ class EmailService(config: EmailConfig) {
 
   def send(fields: EmailFields): Future[SendMessageResult] =
     AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, fields.payload(config.dataExtensionName)))
-
 }
 

--- a/common/src/main/scala/com/gu/emailservices/EmailServicesConfig.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailServicesConfig.scala
@@ -2,11 +2,17 @@ package com.gu.emailservices
 
 import com.typesafe.config.Config
 
-case class EmailServicesConfig(thankYouEmailQueue: String)
+case class EmailServicesConfig(thankYou: EmailConfig, failed: EmailConfig)
+
+case class EmailConfig(queueName: String, dataExtensionName: String)
 
 object EmailServicesConfig {
+  def fromConfig(config: Config): EmailServicesConfig =
+    EmailServicesConfig(
+      fromEmailConfig(config.getConfig("email.thankYou")),
+      fromEmailConfig(config.getConfig("email.failed"))
+    )
 
-  def fromConfig(config: Config): EmailServicesConfig = {
-    EmailServicesConfig(config.getString("email.thankYou.queueName"))
-  }
+  private def fromEmailConfig(config: Config): EmailConfig =
+    EmailConfig(config.getString("queueName"), config.getString("dataExtensionName"))
 }

--- a/common/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/common/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers.exceptions
 import java.net.SocketTimeoutException
 
 import com.amazonaws.services.kms.model._
+import com.amazonaws.services.sqs.model.{AmazonSQSException, InvalidMessageContentsException, QueueDoesNotExistException}
 import com.gu.helpers.WebServiceHelperError
 import io.circe.ParsingFailure
 
@@ -35,4 +36,12 @@ object RetryImplicits {
            _ => new RetryLimited(cause = throwable)
     }
   }
+
+  implicit class AwsSQSConversions(val throwable: AmazonSQSException) {
+    def asRetryException: RetryException = throwable match {
+      case _: InvalidMessageContentsException => new RetryNone(cause = throwable)
+      case _: QueueDoesNotExistException => new RetryLimited(cause = throwable)
+    }
+  }
+
 }

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -8,6 +8,7 @@ import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.support.workers.encoding.Codec
 import com.gu.support.workers.encoding.Helpers.{capitalizingCodec, deriveCodec}
 import com.gu.support.workers.model._
+import com.gu.support.workers.model.monthlyContributions.Contribution
 import io.circe._
 import io.circe.generic.semiauto._
 import org.joda.time.{DateTime, LocalDate}
@@ -55,6 +56,7 @@ trait ModelsCodecs { self: CustomCodecs with InternationalisationCodecs with Hel
 
   implicit val codecUser: Codec[User] = deriveCodec
   implicit val codecContribution: Codec[Contribution] = deriveCodec
+  implicit val codecErrorState: Codec[ErrorState] = deriveCodec
 }
 
 trait HelperCodecs {

--- a/common/src/test/scala/com.gu.config/ConfigSpec.scala
+++ b/common/src/test/scala/com.gu.config/ConfigSpec.scala
@@ -20,6 +20,9 @@ class ConfigSpec extends FlatSpec with Matchers with LazyLogging {
     z.url should be("https://rest.apisandbox.zuora.com/v1")
 
     val e = Configuration.emailServicesConfig
-    e.thankYouEmailQueue should be("contributions-thanks-dev")
+    e.thankYou.queueName should be("contributions-thanks-dev")
+    e.thankYou.dataExtensionName should be("contribution-thank-you")
+    e.failed.queueName should be("contributions-failed-dev")
+    e.failed.dataExtensionName should be("contribution-failed")
   }
 }

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -102,3 +102,9 @@ General codes are here:
 
 ### PayPal
 No request specific error codes as we are only retrieving the user's email address. Just retry on 500s.
+
+### SQS
+|Error                     |Description                                             |Retry? |
+|--------------------------|--------------------------------------------------------|-------|
+|QueueDoesNotExistException|The queue referred to doesn't exist                     |Limited|
+|InvalidMessageContents    |The message contains characters outside the allowed set.|No     |

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateCodecs.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateCodecs.scala
@@ -1,19 +1,15 @@
 package com.gu.support.workers.encoding
 
-import com.gu.support.workers.model.state.CreatePaymentMethodState
-import com.gu.support.workers.model.state.CreateSalesforceContactState
-import com.gu.support.workers.model.state.CreateZuoraSubscriptionState
-import com.gu.support.workers.model.state.SendThankYouEmailState
-import com.gu.zuora.encoding.CustomCodecs._
-import io.circe.generic.semiauto._
-import com.gu.salesforce.Salesforce._
-import io.circe.Decoder
 import com.gu.support.workers.encoding.Helpers.deriveCodec
+import com.gu.support.workers.model.monthlyContributions.state._
+import com.gu.zuora.encoding.CustomCodecs._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
 
 object StateCodecs {
   implicit val createPaymentMethodState: Decoder[CreatePaymentMethodState] = deriveDecoder
-
   implicit val createSalesforceContactStateCodec: Codec[CreateSalesforceContactState] = deriveCodec
   implicit val createZuoraSubscriptionStateCodec: Codec[CreateZuoraSubscriptionState] = deriveCodec
   implicit val sendThankYouEmailStateCodec: Codec[SendThankYouEmailState] = deriveCodec
+  implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateCodecs.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateCodecs.scala
@@ -1,5 +1,6 @@
 package com.gu.support.workers.encoding
 
+import com.gu.salesforce.Salesforce._
 import com.gu.support.workers.encoding.Helpers.deriveCodec
 import com.gu.support.workers.model.monthlyContributions.state._
 import com.gu.zuora.encoding.CustomCodecs._

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -6,8 +6,8 @@ import com.gu.paypal.PayPalService
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.stripe.StripeService
 import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.support.workers.model.state.{CreatePaymentMethodState, CreateSalesforceContactState}
 import com.gu.support.workers.model._
+import com.gu.support.workers.model.monthlyContributions.state.{CreatePaymentMethodState, CreateSalesforceContactState}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce.Salesforce.UpsertData
 import com.gu.services.Services
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.exceptions.SalesforceException
-import com.gu.support.workers.model.state.{CreateSalesforceContactState, CreateZuoraSubscriptionState}
+import com.gu.support.workers.model.monthlyContributions.state.{CreateSalesforceContactState, CreateZuoraSubscriptionState}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.support.workers.model.state.{CreateZuoraSubscriptionState, SendThankYouEmailState}
+import com.gu.support.workers.model.monthlyContributions.state.{CreateZuoraSubscriptionState, SendThankYouEmailState}
 import com.gu.zuora.model._
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.{DateTimeZone, LocalDate}

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -17,6 +17,7 @@ class FailureHandler(emailService: EmailService)
   def this() = this(new EmailService(Configuration.emailServicesConfig.failed))
 
   override protected def handlerFuture(state: FailureHandlerState, context: Context): Future[Unit] = {
+    logger.warn(s"FailureHandler called for error ${state.error.Error}")
     sendEmail(state)
   }
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -4,25 +4,24 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
 import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
-import com.gu.zuora.encoding.CustomCodecs._
+import com.gu.support.workers.model.monthlyContributions.state.FailureHandlerState
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class SendThankYouEmail(thankYouEmailService: EmailService)
-    extends FutureHandler[SendThankYouEmailState, Unit]
+class FailureHandler(emailService: EmailService)
+    extends FutureHandler[FailureHandlerState, Unit]
     with LazyLogging {
-  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou))
+  def this() = this(new EmailService(Configuration.emailServicesConfig.failed))
 
-  override protected def handlerFuture(state: SendThankYouEmailState, context: Context): Future[Unit] = {
+  override protected def handlerFuture(state: FailureHandlerState, context: Context): Future[Unit] = {
     sendEmail(state)
   }
 
-  def sendEmail(state: SendThankYouEmailState): Future[Unit] = {
-    thankYouEmailService.send(EmailFields(
+  def sendEmail(state: FailureHandlerState): Future[Unit] = {
+    emailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
       amount = state.contribution.amount,

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ServicesHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ServicesHandler.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.workers.model.state.StepFunctionUserState
+import com.gu.support.workers.model.monthlyContributions.state.StepFunctionUserState
 import io.circe.{Decoder, Encoder}
 
 import scala.concurrent.duration._

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodSpec.scala
@@ -11,7 +11,7 @@ import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.exceptions.RetryNone
 import com.gu.support.workers.lambdas.CreatePaymentMethod
-import com.gu.support.workers.model.state.CreateSalesforceContactState
+import com.gu.support.workers.model.monthlyContributions.state.CreateSalesforceContactState
 import com.gu.support.workers.model.{CreditCardReferenceTransaction, PayPalReferenceTransaction, PaymentMethod}
 import com.gu.test.tags.objects.IntegrationTest
 import com.gu.zuora.encoding.CustomCodecs._

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodStateDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreatePaymentMethodStateDecoderSpec.scala
@@ -1,14 +1,14 @@
 package com.gu.support.workers
 
 import com.gu.support.workers.Fixtures.{validBaid, _}
-import com.gu.support.workers.model.state.CreatePaymentMethodState
+import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.model.monthlyContributions.state.CreatePaymentMethodState
 import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields}
+import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
-import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.zuora.encoding.CustomCodecs._
 
 class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactDecoderSpec.scala
@@ -1,14 +1,14 @@
 package com.gu.support.workers
 
 import com.gu.support.workers.Fixtures._
+import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.model.monthlyContributions.state.CreateSalesforceContactState
 import com.gu.support.workers.model.{PayPalReferenceTransaction, PaymentMethod}
-import com.gu.support.workers.model.state.CreateSalesforceContactState
+import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
-import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.zuora.encoding.CustomCodecs._
 
 class CreateSalesforceContactDecoderSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateSalesforceContactSpec.scala
@@ -5,10 +5,10 @@ import java.io.ByteArrayOutputStream
 import com.gu.salesforce.Fixtures.salesforceId
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures.createSalesForceContactJson
-import com.gu.support.workers.lambdas.CreateSalesforceContact
-import com.gu.support.workers.model.state.CreateZuoraSubscriptionState
-import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.lambdas.CreateSalesforceContact
+import com.gu.support.workers.model.monthlyContributions.state.CreateZuoraSubscriptionState
+import com.gu.test.tags.annotations.IntegrationTest
 
 @IntegrationTest
 class CreateSalesforceContactSpec extends LambdaSpec {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionSpec.scala
@@ -4,10 +4,10 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures._
-import com.gu.support.workers.lambdas.CreateZuoraSubscription
-import com.gu.support.workers.model.state.SendThankYouEmailState
-import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.lambdas.CreateZuoraSubscription
+import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
+import com.gu.test.tags.annotations.IntegrationTest
 
 @IntegrationTest
 class CreateZuoraSubscriptionSpec extends LambdaSpec {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/FailureHandlerSpec.scala
@@ -1,0 +1,31 @@
+package com.gu.support.workers
+
+import java.io.ByteArrayOutputStream
+
+import com.gu.config.Configuration
+import com.gu.emailservices.{EmailFields, EmailService}
+import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
+import com.gu.support.workers.Fixtures.failureJson
+import com.gu.support.workers.lambdas.FailureHandler
+import org.joda.time.DateTime
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+class FailureHandlerSpec extends AsyncFlatSpec with Matchers with MockContext{
+
+  "EmailService" should "send a failure email" in {
+    val service = new EmailService(Configuration.emailServicesConfig.failed)
+    val email = "rupert.bates@theguardian.com"
+    service.send(EmailFields(email, DateTime.now(), 5, "GBP", "UK", "")).map(result => result.getMessageId should not be("") )
+  }
+
+  "FailureHandler lambda" should "add message to sqs queue" in {
+    val failureHandler = new FailureHandler()
+
+    val outStream = new ByteArrayOutputStream()
+
+    failureHandler.handleRequest(failureJson.asInputStream(), outStream, context)
+
+    outStream.toClass[Unit]() shouldEqual ((): Unit)
+  }
+
+}

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -115,4 +115,16 @@ object Fixtures {
        {
        }
      """
+
+  val failureJson =
+    s"""{
+       |  $requestIdJson,
+       |  $userJson,
+       |  "contribution": $contributionJson,
+       |  "error": {
+       |    "Error": "com.gu.support.workers.exceptions.ErrorHandler.logAndRethrow(ErrorHandler.scala:33)",
+       |    "Cause": "The card has expired"
+       |  }
+       |}
+     """.stripMargin
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -6,8 +6,9 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 
-abstract class LambdaSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
+abstract class LambdaSpec extends FlatSpec with Matchers with MockitoSugar with MockContext with LazyLogging
+
+trait MockContext extends MockitoSugar {
   val context = mock[Context]
   when(context.getRemainingTimeInMillis).thenReturn(60000)
-
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.2"
+  val supportModels = "com.gu" %% "support-models" % "0.3"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val awsLambdas = "com.amazonaws" % "aws-lambda-java-core" % "1.1.0"


### PR DESCRIPTION
Add a failure handler state to the monthly contribution sign up step function. 

This handler will deal with sign ups that have permanently failed, for instance due to card payment failures, by emailing the user to inform of the failure.

Note that we do not invoke this handler if the 'Thank you' email fails because the sign up will have already succeeded by this point.