### PR TITLE
Rename the private conf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When running locally you can avoid loading config from S3 on each run and load i
 
 * Retrieve credentials from S3 with the command:
 
-    `sudo aws s3 cp s3://support-workers-private/DEV/support.private.conf /etc/gu/support.private.conf --profile membership`
+    `sudo aws s3 cp s3://support-workers-private/DEV/support-workers.private.conf /etc/gu/support-workers.private.conf --profile membership`
 
 * Set an environment variable to false by adding the following to your bashrc:
 

--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -1,9 +1,9 @@
 # Public config only in this file private values should go in the files specified below:
 config.private {
-  local = "/etc/gu/support.private.conf"
+  local = "/etc/gu/support-workers.private.conf"
   s3 {
-    DEV = "s3://support-workers-private/DEV/support.private.conf"
-    PROD = "s3://support-workers-private/PROD/support.private.conf"
+    DEV = "s3://support-workers-private/DEV/support-workers.private.conf"
+    PROD = "s3://support-workers-private/PROD/support-workers.private.conf"
   }
 }
 


### PR DESCRIPTION
Currently support-workers and support-frontend both have a private conf file called support.private.conf which means that it is difficult to work on them both locally as the conf files either overwrite each other or have to be merged

[Trello card here](https://trello.com/c/kMjYGnXa/649-rename-private-conf-file-for-support-projects-to-allow-local-development-on-both-projects)