### PR TITLE
Json wrapper

### DIFF
--- a/common/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.kms.model._
 import com.gu.aws.CredentialsProvider
 import com.gu.config.Configuration.awsConfig
 
-object  Encryption {
+object Encryption {
   private val encryption = if (awsConfig.useEncryption) new AwsEncryptionProvider() else new PassThroughEncryptionProvider()
 
   def decrypt(data: Array[Byte]): String = encryption.decrypt(data)

--- a/common/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.kms.model._
 import com.gu.aws.CredentialsProvider
 import com.gu.config.Configuration.awsConfig
 
-object Encryption {
+object  Encryption {
   private val encryption = if (awsConfig.useEncryption) new AwsEncryptionProvider() else new PassThroughEncryptionProvider()
 
   def decrypt(data: Array[Byte]): String = encryption.decrypt(data)
@@ -50,7 +50,6 @@ class PassThroughEncryptionProvider extends EncryptionProvider {
 }
 
 sealed trait EncryptionProvider {
-  val utf8 = "UTF-8"
 
   def decrypt(data: Array[Byte]): String
 

--- a/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
@@ -30,7 +30,9 @@ object Wrapper {
   }
 
   def wrap[T](value: T)(implicit encoder: Encoder[T]): JsonWrapper =
-    JsonWrapper(encodeToBase64String(encrypt(value.asJson.noSpaces)))
+    wrapString(value.asJson.noSpaces)
+
+  def wrapString(string: String): JsonWrapper = JsonWrapper(encodeToBase64String(encrypt(string)))
 
   def encodeToBase64String(value: Array[Byte]): String = new String(Base64.getEncoder.encode(value))
 }

--- a/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
@@ -1,0 +1,36 @@
+package com.gu.support.workers.encoding
+
+import java.io.InputStream
+import java.util.Base64
+
+import cats.syntax.either._
+import com.gu.support.workers.encoding.Encryption.encrypt
+import com.gu.support.workers.model.JsonWrapper
+import io.circe.Encoder
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.parser._
+import io.circe.syntax._
+
+import scala.io.Source
+import scala.util.Try
+
+/**
+ * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
+ * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String.
+ * This class helps with that
+ */
+object Wrapper {
+  implicit val jsonEncoder = deriveEncoder[JsonWrapper]
+  implicit val jsonDecoder = deriveDecoder[JsonWrapper]
+
+  def unWrap(is: InputStream): Try[JsonWrapper] = {
+    val t = Try(Source.fromInputStream(is).mkString).flatMap(decode[JsonWrapper](_).toTry)
+    is.close()
+    t
+  }
+
+  def wrap[T](value: T)(implicit encoder: Encoder[T]): JsonWrapper =
+    JsonWrapper(encodeToBase64String(encrypt(value.asJson.noSpaces)))
+
+  def encodeToBase64String(value: Array[Byte]): String = new String(Base64.getEncoder.encode(value))
+}

--- a/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
@@ -5,9 +5,9 @@ import java.util.Base64
 
 import cats.syntax.either._
 import com.gu.support.workers.encoding.Encryption.encrypt
+import com.gu.support.workers.encoding.Helpers.deriveCodec
 import com.gu.support.workers.model.JsonWrapper
 import io.circe.Encoder
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.parser._
 import io.circe.syntax._
 
@@ -20,8 +20,7 @@ import scala.util.Try
  * This class helps with that
  */
 object Wrapper {
-  implicit val jsonEncoder = deriveEncoder[JsonWrapper]
-  implicit val jsonDecoder = deriveDecoder[JsonWrapper]
+  implicit val jsonCodec = deriveCodec[JsonWrapper]
 
   def unWrap(is: InputStream): Try[JsonWrapper] = {
     val t = Try(Source.fromInputStream(is).mkString).flatMap(decode[JsonWrapper](_).toTry)

--- a/common/src/main/scala/com/gu/support/workers/encoding/package.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/package.scala
@@ -1,0 +1,5 @@
+package com.gu.support.workers
+
+package object encoding {
+  val utf8 = "UTF-8"
+}

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
@@ -18,18 +18,20 @@ object Conversions {
     def asInputStream()(implicit encoder: Encoder[T]): ByteArrayInputStream = {
       val convertStream = new ByteArrayOutputStream()
       convertStream.write(Encryption.encrypt(self.asJson.noSpaces))
-      new ByteArrayInputStream(convertStream.toByteArray)
+      convertStream.toInputStream()
     }
   }
 
   implicit class FromOutputStream(val self: ByteArrayOutputStream) {
     def toClass[T]()(implicit decoder: Decoder[T]): T = {
-      val is = new ByteArrayInputStream(self.toByteArray)
+      val is = self.toInputStream()
       val str = Encryption.decrypt(Streamable.bytes(is))
       val t = Try(str).flatMap(decode[T](_).toTry)
       is.close()
       t.get
     }
+
+    def toInputStream(): ByteArrayInputStream = new ByteArrayInputStream(self.toByteArray)
   }
 
   implicit class StringInputStreamConversions[String](val str: String) {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import cats.syntax.either._
-import com.gu.support.workers.encoding.Encryption
+import com.gu.support.workers.encoding.{Encryption, utf8}
 import io.circe.parser._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
@@ -17,21 +17,21 @@ object Conversions {
 
     def asInputStream()(implicit encoder: Encoder[T]): ByteArrayInputStream = {
       val convertStream = new ByteArrayOutputStream()
-      convertStream.write(Encryption.encrypt(self.asJson.noSpaces))
-      convertStream.toInputStream()
+      convertStream.write(self.asJson.noSpaces.getBytes(utf8))
+      convertStream.toInputStream
     }
   }
 
   implicit class FromOutputStream(val self: ByteArrayOutputStream) {
     def toClass[T]()(implicit decoder: Decoder[T]): T = {
-      val is = self.toInputStream()
+      val is = self.toInputStream
       val str = Encryption.decrypt(Streamable.bytes(is))
       val t = Try(str).flatMap(decode[T](_).toTry)
       is.close()
       t.get
     }
 
-    def toInputStream(): ByteArrayInputStream = new ByteArrayInputStream(self.toByteArray)
+    def toInputStream: ByteArrayInputStream = new ByteArrayInputStream(self.toByteArray)
   }
 
   implicit class StringInputStreamConversions[String](val str: String) {
@@ -39,7 +39,7 @@ object Conversions {
     def asInputStream()(implicit encoder: Encoder[String]): ByteArrayInputStream = {
       val convertStream = new ByteArrayOutputStream()
 
-      convertStream.write(Encryption.encrypt(str.toString))
+      convertStream.write(str.toString.getBytes(utf8))
       new ByteArrayInputStream(convertStream.toByteArray)
     }
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -2,8 +2,9 @@ package com.gu.support.workers
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.Fixtures.createPayPalPaymentMethodJson
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrap}
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas._
 import com.gu.test.tags.annotations.IntegrationTest
 
@@ -11,13 +12,13 @@ import com.gu.test.tags.annotations.IntegrationTest
 class EndToEndSpec extends LambdaSpec {
   "The monthly contribution lambdas" should "chain successfully" in {
     logger.info(createPayPalPaymentMethodJson)
-    val output = createPayPalPaymentMethodJson.asInputStream()
+    val output = wrap(createPayPalPaymentMethodJson)
       .chain(new CreatePaymentMethod())
       .chain(new CreateSalesforceContact())
       .chain(new CreateZuoraSubscription())
       .last(new SendThankYouEmail())
 
-    output.toClass[Unit]() shouldEqual ((): Unit)
+    Encoding.in[Unit](output.toInputStream()).isSuccess should be(true)
   }
 
   implicit class InputStreamChaining(val stream: InputStream) {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -2,9 +2,7 @@ package com.gu.support.workers
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
-import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrap}
-import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas._
 import com.gu.test.tags.annotations.IntegrationTest
 
@@ -18,7 +16,7 @@ class EndToEndSpec extends LambdaSpec {
       .chain(new CreateZuoraSubscription())
       .last(new SendThankYouEmail())
 
-    Encoding.in[Unit](output.toInputStream()).isSuccess should be(true)
+    assertUnit(output)
   }
 
   implicit class InputStreamChaining(val stream: InputStream) {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
-import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrap}
+import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrapFixture}
 import com.gu.support.workers.lambdas._
 import com.gu.test.tags.annotations.IntegrationTest
 
@@ -10,7 +10,7 @@ import com.gu.test.tags.annotations.IntegrationTest
 class EndToEndSpec extends LambdaSpec {
   "The monthly contribution lambdas" should "chain successfully" in {
     logger.info(createPayPalPaymentMethodJson)
-    val output = wrap(createPayPalPaymentMethodJson)
+    val output = wrapFixture(createPayPalPaymentMethodJson)
       .chain(new CreatePaymentMethod())
       .chain(new CreateSalesforceContact())
       .chain(new CreateZuoraSubscription())

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayInputStream
 import com.gu.salesforce.Fixtures.idId
 import com.gu.support.workers.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Wrapper
-import com.gu.support.workers.encoding.Wrapper.jsonEncoder
+import com.gu.support.workers.encoding.Wrapper.jsonCodec
 import io.circe.syntax._
 
 object Fixtures {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -1,8 +1,14 @@
 package com.gu.support.workers
 
-import com.gu.salesforce.Fixtures.idId
+import java.io.ByteArrayInputStream
 
+import com.gu.salesforce.Fixtures.idId
+import com.gu.support.workers.Conversions.StringInputStreamConversions
+import com.gu.support.workers.encoding.Wrapper
+import com.gu.support.workers.encoding.Wrapper.jsonEncoder
+import io.circe.syntax._
 object Fixtures {
+  def wrap(string: String): ByteArrayInputStream = Wrapper.wrapString(string).asJson.noSpaces.asInputStream
   val userJson =
     s"""
       "user":{
@@ -52,6 +58,7 @@ object Fixtures {
                   "stripeToken": "$stripeToken"
                 }
                 """
+
   val createPayPalPaymentMethodJson =
     s"""{
           $requestIdJson,

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -7,8 +7,10 @@ import com.gu.support.workers.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Wrapper
 import com.gu.support.workers.encoding.Wrapper.jsonEncoder
 import io.circe.syntax._
+
 object Fixtures {
-  def wrap(string: String): ByteArrayInputStream = Wrapper.wrapString(string).asJson.noSpaces.asInputStream
+  def wrapFixture(string: String): ByteArrayInputStream = Wrapper.wrapString(string).asJson.noSpaces.asInputStream
+
   val userJson =
     s"""
       "user":{
@@ -87,16 +89,16 @@ object Fixtures {
 
   val thankYouEmailJson =
     s"""{
-        |  $requestIdJson,
-        |  $userJson,
-        |  "contribution": $contributionJson,
-        |  "paymentMethod": $payPalPaymentMethod,
-        |  "salesForceContact": {
-        |    "Id": "123",
-        |    "AccountId": "123"
-        |  },
-        |  "accountNumber": "123"
-        |}
+       |  $requestIdJson,
+       |  $userJson,
+       |  "contribution": $contributionJson,
+       |  "paymentMethod": $payPalPaymentMethod,
+       |  "salesForceContact": {
+       |    "Id": "123",
+       |    "AccountId": "123"
+       |  },
+       |  "accountNumber": "123"
+       |}
      """.stripMargin
 
   val updateMembersDataAPIJson =

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 abstract class LambdaSpec extends FlatSpec with Matchers with MockitoSugar with MockContext with LazyLogging {
   def assertUnit(output: ByteArrayOutputStream): Assertion =
-    Encoding.in[Unit](output.toInputStream()).isSuccess should be(true)
+    Encoding.in[Unit](output.toInputStream).isSuccess should be(true)
 }
 trait MockContext extends MockitoSugar {
   val context = mock[Context]

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -1,13 +1,19 @@
 package com.gu.support.workers
 
+import java.io.ByteArrayOutputStream
+
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.encoding.Encoding
 import com.typesafe.scalalogging.LazyLogging
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{Assertion, FlatSpec, Matchers}
 
-abstract class LambdaSpec extends FlatSpec with Matchers with MockitoSugar with MockContext with LazyLogging
-
+abstract class LambdaSpec extends FlatSpec with Matchers with MockitoSugar with MockContext with LazyLogging {
+  def assertUnit(output: ByteArrayOutputStream): Assertion =
+    Encoding.in[Unit](output.toInputStream()).isSuccess should be(true)
+}
 trait MockContext extends MockitoSugar {
   val context = mock[Context]
   when(context.getRemainingTimeInMillis).thenReturn(60000)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.support.workers
 
-import com.gu.support.workers.Fixtures.{contributionJson, wrap}
+import com.gu.support.workers.Fixtures.{contributionJson, wrapFixture}
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.zuora.encoding.CustomCodecs.codecContribution
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class WrapperSpec extends FlatSpec with Matchers {
   "Wrapper" should "be able to round trip some json" in {
-    val wrapped = wrap(contributionJson)
+    val wrapped = wrapFixture(contributionJson)
 
     val contribution = Encoding.in[Contribution](wrapped)
     contribution.isSuccess should be(true)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,0 +1,16 @@
+package com.gu.support.workers
+
+import com.gu.support.workers.Fixtures.{contributionJson, wrap}
+import com.gu.support.workers.encoding.Encoding
+import com.gu.support.workers.model.monthlyContributions.Contribution
+import com.gu.zuora.encoding.CustomCodecs.codecContribution
+import org.scalatest.{FlatSpec, Matchers}
+
+class WrapperSpec extends FlatSpec with Matchers {
+  "Wrapper" should "be able to round trip some json" in {
+    val wrapped = wrap(contributionJson)
+
+    val contribution = Encoding.in[Contribution](wrapped)
+    contribution.isSuccess should be(true)
+  }
+}

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/PayPalErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/PayPalErrorsSpec.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
 import com.gu.paypal.{PayPalConfig, PayPalService}
-import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrap}
+import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreatePaymentMethod
@@ -20,7 +20,7 @@ class PayPalErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createPayPalPaymentMethodJson), outStream, context)
     }
   }
 
@@ -34,7 +34,7 @@ class PayPalErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createPayPalPaymentMethodJson), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/PayPalErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/PayPalErrorsSpec.scala
@@ -5,8 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
 import com.gu.paypal.{PayPalConfig, PayPalService}
-import com.gu.support.workers.Conversions.StringInputStreamConversions
-import com.gu.support.workers.Fixtures.createPayPalPaymentMethodJson
+import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrap}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreatePaymentMethod
@@ -21,7 +20,7 @@ class PayPalErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(createPayPalPaymentMethodJson.asInputStream(), outStream, context)
+      createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
     }
   }
 
@@ -35,7 +34,7 @@ class PayPalErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(createPayPalPaymentMethodJson.asInputStream(), outStream, context)
+      createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -6,7 +6,7 @@ import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
 import com.gu.stripe.{Stripe, StripeService}
-import com.gu.support.workers.Fixtures.{createStripePaymentMethodJson, wrap}
+import com.gu.support.workers.Fixtures.{createStripePaymentMethodJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.{RetryNone, RetryUnlimited}
 import com.gu.support.workers.lambdas.CreatePaymentMethod
@@ -22,7 +22,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
     }
   }
 
@@ -36,7 +36,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.
@@ -55,7 +55,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryNone] should be thrownBy {
-      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
     }
 
     server.shutdown()

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -6,8 +6,7 @@ import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
 import com.gu.stripe.{Stripe, StripeService}
-import com.gu.support.workers.Conversions.StringInputStreamConversions
-import com.gu.support.workers.Fixtures.createStripePaymentMethodJson
+import com.gu.support.workers.Fixtures.{createStripePaymentMethodJson, wrap}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.{RetryNone, RetryUnlimited}
 import com.gu.support.workers.lambdas.CreatePaymentMethod
@@ -23,7 +22,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(createStripePaymentMethodJson.asInputStream(), outStream, context)
+      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
     }
   }
 
@@ -37,7 +36,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(createStripePaymentMethodJson.asInputStream(), outStream, context)
+      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.
@@ -56,7 +55,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryNone] should be thrownBy {
-      createPaymentMethod.handleRequest(createStripePaymentMethodJson.asInputStream(), outStream, context)
+      createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
     }
 
     server.shutdown()

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -5,8 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
-import com.gu.support.workers.Conversions.StringInputStreamConversions
-import com.gu.support.workers.Fixtures.createZuoraSubscriptionJson
+import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrap}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
@@ -46,7 +45,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val createZuoraSubscription = new CreateZuoraSubscription(timeoutServices)
     val outputStream = new ByteArrayOutputStream()
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(createZuoraSubscriptionJson.asInputStream(), outputStream, context)
+      createZuoraSubscription.handleRequest(wrap(createZuoraSubscriptionJson), outputStream, context)
     }
   }
 
@@ -60,7 +59,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(createZuoraSubscriptionJson.asInputStream(), outStream, context)
+      createZuoraSubscription.handleRequest(wrap(createZuoraSubscriptionJson), outStream, context)
     }
 
     server.shutdown()

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
-import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrap}
+import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
@@ -45,7 +45,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val createZuoraSubscription = new CreateZuoraSubscription(timeoutServices)
     val outputStream = new ByteArrayOutputStream()
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrap(createZuoraSubscriptionJson), outputStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson), outputStream, context)
     }
   }
 
@@ -59,7 +59,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrap(createZuoraSubscriptionJson), outStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson), outStream, context)
     }
 
     server.shutdown()

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.salesforce.Fixtures.salesforceId
 import com.gu.support.workers.Conversions.FromOutputStream
-import com.gu.support.workers.Fixtures.{createSalesForceContactJson, wrap}
+import com.gu.support.workers.Fixtures.{createSalesForceContactJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs._
@@ -20,7 +20,7 @@ class CreateSalesforceContactSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createContact.handleRequest(wrap(createSalesForceContactJson), outStream, context)
+    createContact.handleRequest(wrapFixture(createSalesForceContactJson), outStream, context)
 
     val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
     result.isSuccess should be(true)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -22,7 +22,7 @@ class CreateSalesforceContactSpec extends LambdaSpec {
 
     createContact.handleRequest(wrap(createSalesForceContactJson), outStream, context)
 
-    val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream())
+    val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
     result.isSuccess should be(true)
     result.get.salesForceContact.Id should be(salesforceId)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -3,9 +3,10 @@ package com.gu.support.workers.integration
 import java.io.ByteArrayOutputStream
 
 import com.gu.salesforce.Fixtures.salesforceId
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.Fixtures.createSalesForceContactJson
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.Fixtures.{createSalesForceContactJson, wrap}
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.lambdas.CreateSalesforceContact
 import com.gu.support.workers.model.monthlyContributions.state.CreateZuoraSubscriptionState
@@ -19,8 +20,10 @@ class CreateSalesforceContactSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createContact.handleRequest(createSalesForceContactJson.asInputStream(), outStream, context)
+    createContact.handleRequest(wrap(createSalesForceContactJson), outStream, context)
 
-    outStream.toClass[CreateZuoraSubscriptionState]().salesForceContact.Id should be(salesforceId)
+    val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream())
+    result.isSuccess should be(true)
+    result.get.salesForceContact.Id should be(salesforceId)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -2,9 +2,10 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
+import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures._
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
@@ -18,9 +19,9 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createZuora.handleRequest(createZuoraSubscriptionJson.asInputStream(), outStream, context)
+    createZuora.handleRequest(wrap(createZuoraSubscriptionJson), outStream, context)
 
-    val sendThankYouEmail = outStream.toClass[SendThankYouEmailState]
+    val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream()).get
     sendThankYouEmail.accountNumber.length should be > 0
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -21,7 +21,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
     createZuora.handleRequest(wrap(createZuoraSubscriptionJson), outStream, context)
 
-    val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream()).get
+    val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
     sendThankYouEmail.accountNumber.length should be > 0
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -19,7 +19,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createZuora.handleRequest(wrap(createZuoraSubscriptionJson), outStream, context)
+    createZuora.handleRequest(wrapFixture(createZuoraSubscriptionJson), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
     sendThankYouEmail.accountNumber.length should be > 0

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrap}
+import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.test.tags.annotations.IntegrationTest
@@ -15,7 +15,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    sendThankYouEmail.handleRequest(wrap(thankYouEmailJson), outStream, context)
+    sendThankYouEmail.handleRequest(wrapFixture(thankYouEmailJson), outStream, context)
 
     assertUnit(outStream)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -2,10 +2,8 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrap}
 import com.gu.support.workers.LambdaSpec
-import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.test.tags.annotations.IntegrationTest
 
@@ -19,7 +17,6 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
     sendThankYouEmail.handleRequest(wrap(thankYouEmailJson), outStream, context)
 
-    val state = Encoding.in[Unit](outStream.toInputStream())
-    state.isSuccess should be(true)
+    assertUnit(outStream)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -2,9 +2,10 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.Fixtures.thankYouEmailJson
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrap}
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.test.tags.annotations.IntegrationTest
 
@@ -16,8 +17,9 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    sendThankYouEmail.handleRequest(thankYouEmailJson.asInputStream(), outStream, context)
+    sendThankYouEmail.handleRequest(wrap(thankYouEmailJson), outStream, context)
 
-    outStream.toClass[Unit]() shouldEqual ((): Unit)
+    val state = Encoding.in[Unit](outStream.toInputStream())
+    state.isSuccess should be(true)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/UpdateMembersDataAPISpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/UpdateMembersDataAPISpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrap}
+import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.lambdas.UpdateMembersDataAPI
 import com.gu.test.tags.annotations.IntegrationTest
@@ -16,7 +16,7 @@ class UpdateMembersDataAPISpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    updateMembersDataAPI.handleRequest(wrap(updateMembersDataAPIJson), outStream, context)
+    updateMembersDataAPI.handleRequest(wrapFixture(updateMembersDataAPIJson), outStream, context)
 
     assertUnit(outStream)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/UpdateMembersDataAPISpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/UpdateMembersDataAPISpec.scala
@@ -2,8 +2,7 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.Fixtures.updateMembersDataAPIJson
+import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrap}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.lambdas.UpdateMembersDataAPI
 import com.gu.test.tags.annotations.IntegrationTest
@@ -11,13 +10,14 @@ import com.gu.test.tags.annotations.IntegrationTest
 @IntegrationTest
 class UpdateMembersDataAPISpec extends LambdaSpec {
 
-  "UpdateMembersDataAPI lambda" should "make post request to members data api" in {
+  //"UpdateMembersDataAPI lambda" Ignored because we don't currently have a code environment for members data api
+  ignore should "make post request to members data api" in {
     val updateMembersDataAPI = new UpdateMembersDataAPI()
 
     val outStream = new ByteArrayOutputStream()
 
-    updateMembersDataAPI.handleRequest(updateMembersDataAPIJson.asInputStream(), outStream, context)
+    updateMembersDataAPI.handleRequest(wrap(updateMembersDataAPIJson), outStream, context)
 
-    outStream.toClass[Unit]() shouldEqual ((): Unit)
+    assertUnit(outStream)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -29,7 +29,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
+    createPaymentMethod.handleRequest(wrapFixture(createPayPalPaymentMethodJson), outStream, context)
 
     //Check the output
     val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
@@ -49,7 +49,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
+    createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
 
     //Check the output
     val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -9,6 +9,7 @@ import com.gu.stripe.{Stripe, StripeService}
 import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.exceptions.RetryNone
 import com.gu.support.workers.model.monthlyContributions.state.CreateSalesforceContactState
@@ -28,14 +29,14 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(createPayPalPaymentMethodJson.asInputStream(), outStream, context)
+    createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
 
-    //We can't convert directly to a PayPalReferenceTransaction with Circe, as the structure of the
-    //Json produced for a PaymentMethod is different from that for a PayPalReferenceTransaction.
-    //See CirceEncodingBehaviourSpec for more details
+    //Check the output
+    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream())
 
-    outStream.toClass[CreateSalesforceContactState]() match {
-      case state @ CreateSalesforceContactState(_, _, _, payPal: PayPalReferenceTransaction) =>
+    createSalesforceContactState.isSuccess should be(true)
+    createSalesforceContactState.get.paymentMethod match {
+      case payPal: PayPalReferenceTransaction =>
         payPal.paypalBaid should be(validBaid)
         payPal.paypalEmail should be("membership.paypal-buyer@theguardian.com")
       case _ => fail()
@@ -48,13 +49,14 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(createStripePaymentMethodJson.asInputStream(), outStream, context)
+    createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
 
-    //We can't convert directly to a CreditCardReferenceTransaction with Circe, as the structure of the
-    //Json produced for a PaymentMethod is different from that for a CreditCardReferenceTransaction.
-    //See CirceEncodingBehaviourSpec for more details
-    outStream.toClass[CreateSalesforceContactState]() match {
-      case CreateSalesforceContactState(_, _, _, stripe: CreditCardReferenceTransaction) =>
+    //Check the output
+    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream())
+
+    createSalesforceContactState.isSuccess should be(true)
+    createSalesforceContactState.get.paymentMethod match {
+      case stripe: CreditCardReferenceTransaction =>
         stripe.tokenId should be("1234")
       case _ => fail()
     }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -32,7 +32,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
     createPaymentMethod.handleRequest(wrap(createPayPalPaymentMethodJson), outStream, context)
 
     //Check the output
-    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream())
+    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
 
     createSalesforceContactState.isSuccess should be(true)
     createSalesforceContactState.get.paymentMethod match {
@@ -52,7 +52,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
     createPaymentMethod.handleRequest(wrap(createStripePaymentMethodJson), outStream, context)
 
     //Check the output
-    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream())
+    val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
 
     createSalesforceContactState.isSuccess should be(true)
     createSalesforceContactState.get.paymentMethod match {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -4,9 +4,10 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.Fixtures.failureJson
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.Fixtures.{failureJson, wrap}
 import com.gu.support.workers.MockContext
+import com.gu.support.workers.encoding.Encoding
 import org.joda.time.DateTime
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -23,9 +24,9 @@ class FailureHandlerSpec extends AsyncFlatSpec with Matchers with MockContext {
 
     val outStream = new ByteArrayOutputStream()
 
-    failureHandler.handleRequest(failureJson.asInputStream(), outStream, context)
+    failureHandler.handleRequest(wrap(failureJson), outStream, context)
 
-    outStream.toClass[Unit]() shouldEqual ((): Unit)
+    Encoding.in[Unit](outStream.toInputStream()).isSuccess should be(true)
   }
 
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -4,14 +4,13 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
-import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures.{failureJson, wrap}
-import com.gu.support.workers.MockContext
-import com.gu.support.workers.encoding.Encoding
+import com.gu.support.workers.LambdaSpec
 import org.joda.time.DateTime
-import org.scalatest.{AsyncFlatSpec, Matchers}
 
-class FailureHandlerSpec extends AsyncFlatSpec with Matchers with MockContext {
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class FailureHandlerSpec extends LambdaSpec {
 
   "EmailService" should "send a failure email" in {
     val service = new EmailService(Configuration.emailServicesConfig.failed)
@@ -26,7 +25,7 @@ class FailureHandlerSpec extends AsyncFlatSpec with Matchers with MockContext {
 
     failureHandler.handleRequest(wrap(failureJson), outStream, context)
 
-    Encoding.in[Unit](outStream.toInputStream()).isSuccess should be(true)
+    assertUnit(outStream)
   }
 
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
-import com.gu.support.workers.Fixtures.{failureJson, wrap}
+import com.gu.support.workers.Fixtures.{failureJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import org.joda.time.DateTime
 
@@ -23,7 +23,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    failureHandler.handleRequest(wrap(failureJson), outStream, context)
+    failureHandler.handleRequest(wrapFixture(failureJson), outStream, context)
 
     assertUnit(outStream)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
@@ -3,13 +3,14 @@ package com.gu.support.workers.lambdas
 import java.io.ByteArrayOutputStream
 
 import com.gu.membersDataAPI.{MembersDataService, UpdateResponse}
-import com.gu.support.workers.Conversions.{FromOutputStream, StringInputStreamConversions}
-import com.gu.support.workers.LambdaSpec
-import com.gu.support.workers.Fixtures.updateMembersDataAPIJson
-import org.scalatest.mockito.MockitoSugar
-import org.mockito.Mockito.{times, verify, when}
 import com.gu.salesforce.Fixtures.idId
 import com.gu.services.{ServiceProvider, Services}
+import com.gu.support.workers.Conversions.FromOutputStream
+import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrap}
+import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.mockito.MockitoSugar
 
 import scala.concurrent.Future
 
@@ -32,9 +33,9 @@ class UpdateMembersDataAPISpec extends LambdaSpec with MockitoSugar {
 
     val outStream = new ByteArrayOutputStream()
 
-    updateMembersDataAPI.handleRequest(updateMembersDataAPIJson.asInputStream(), outStream, context)
+    updateMembersDataAPI.handleRequest(wrap(updateMembersDataAPIJson), outStream, context)
 
-    outStream.toClass[Unit]() shouldEqual ((): Unit)
+    Encoding.in[Unit](outStream.toInputStream()).isSuccess should be(true)
 
     verify(membersDataServiceMock, times(1)).update(idId, isTestUser = false)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.membersDataAPI.{MembersDataService, UpdateResponse}
 import com.gu.salesforce.Fixtures.idId
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrap}
+import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.mockito.MockitoSugar
@@ -31,7 +31,7 @@ class UpdateMembersDataAPISpec extends LambdaSpec with MockitoSugar {
 
     val outStream = new ByteArrayOutputStream()
 
-    updateMembersDataAPI.handleRequest(wrap(updateMembersDataAPIJson), outStream, context)
+    updateMembersDataAPI.handleRequest(wrapFixture(updateMembersDataAPIJson), outStream, context)
 
     assertUnit(outStream)
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/UpdateMembersDataAPISpec.scala
@@ -5,10 +5,8 @@ import java.io.ByteArrayOutputStream
 import com.gu.membersDataAPI.{MembersDataService, UpdateResponse}
 import com.gu.salesforce.Fixtures.idId
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures.{updateMembersDataAPIJson, wrap}
 import com.gu.support.workers.LambdaSpec
-import com.gu.support.workers.encoding.Encoding
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.mockito.MockitoSugar
 
@@ -35,7 +33,7 @@ class UpdateMembersDataAPISpec extends LambdaSpec with MockitoSugar {
 
     updateMembersDataAPI.handleRequest(wrap(updateMembersDataAPIJson), outStream, context)
 
-    Encoding.in[Unit](outStream.toInputStream()).isSuccess should be(true)
+    assertUnit(outStream)
 
     verify(membersDataServiceMock, times(1)).update(idId, isTestUser = false)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.4"
+  val supportModels = "com.gu" %% "support-models" % "0.5-SNAPSHOT"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val awsLambdas = "com.amazonaws" % "aws-lambda-java-core" % "1.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.5-SNAPSHOT"
+  val supportModels = "com.gu" %% "support-models" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val awsLambdas = "com.amazonaws" % "aws-lambda-java-core" % "1.1.0"


### PR DESCRIPTION
AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
state, we need to Base64 encode it and then wrap it in a Json 'wrapper' object.

This PR does that and then fixes all the tests
