### PR TITLE
Add KMS key ARNs to CloudFormation

### DIFF
--- a/cloud-formation/src/cfn-template.yaml
+++ b/cloud-formation/src/cfn-template.yaml
@@ -16,7 +16,14 @@ Parameters:
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
-
+Mappings:
+  StageVariables:
+    CODE:
+      AwsKeyARN: arn:aws:kms:eu-west-1:865473395570:key/89f17663-c79e-4104-b718-ee0986402ad9
+      EmailQueueARN: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks-dev
+    PROD:
+      AwsKeyARN: arn:aws:kms:eu-west-1:865473395570:key/d7aed06c-e961-4078-8604-0aeedae08613
+      EmailQueueARN: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks
 Resources:
   LambdaExecutionRole:
     Type: "AWS::IAM::Role"
@@ -44,9 +51,7 @@ Resources:
               Action:
               - sqs:GetQueueUrl
               - sqs:SendMessage
-              Resource:
-              - arn:aws:sqs:eu-west-1:865473395570:contributions-thanks
-              - arn:aws:sqs:eu-west-1:865473395570:contributions-thanks-dev
+              Resource: !FindInMap [ StageVariables, !Ref Stage, EmailQueueARN ]
         - PolicyName: CloudWatchLogging
           PolicyDocument:
             Version: '2012-10-17'
@@ -64,7 +69,7 @@ Resources:
               - Effect: Allow
                 Action:
                 - kms:Encrypt
-                Resource: arn:aws:kms:eu-west-1:865473395570:key/89f17663-c79e-4104-b718-ee0986402ad9
+                Resource: !FindInMap [ StageVariables, !Ref Stage, AwsKeyARN ]
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/cloud-formation/src/cfn-template.yaml
+++ b/cloud-formation/src/cfn-template.yaml
@@ -57,6 +57,14 @@ Resources:
                 - logs:PutLogEvents
                 - logs:DescribeLogStreams
               Resource: arn:aws:logs:*:*:*
+        - PolicyName: KMSEncryption
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                - kms:Encrypt
+                Resource: arn:aws:kms:eu-west-1:865473395570:key/89f17663-c79e-4104-b718-ee0986402ad9
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
@@ -6,10 +6,11 @@ import java.util.Base64
 import cats.syntax.either._
 import com.gu.support.workers.encoding.Encryption._
 import com.gu.support.workers.encoding.Wrapper._
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
-private[workers] object Encoding {
+private[workers] object Encoding extends LazyLogging{
 
   import io.circe._
   import io.circe.parser._
@@ -20,7 +21,7 @@ private[workers] object Encoding {
       wrapper <- unWrap(is)
       state <- Try(Base64.getDecoder.decode(wrapper.state))
       decrypted <- Try(decrypt(state))
-      result <- decode[T](decrypted).toTry
+      result <- {logger.info(s"decrypted state:\n$decrypted"); decode[T](decrypted).toTry}
     } yield result
 
   def out[T](value: T, os: OutputStream)(implicit encoder: Encoder[T]): Try[Unit] = {

--- a/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
@@ -6,11 +6,10 @@ import java.util.Base64
 import cats.syntax.either._
 import com.gu.support.workers.encoding.Encryption._
 import com.gu.support.workers.encoding.Wrapper._
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
-private[workers] object Encoding extends LazyLogging{
+private[workers] object Encoding {
 
   import io.circe._
   import io.circe.parser._
@@ -21,7 +20,7 @@ private[workers] object Encoding extends LazyLogging{
       wrapper <- unWrap(is)
       state <- Try(Base64.getDecoder.decode(wrapper.state))
       decrypted <- Try(decrypt(state))
-      result <- {logger.info(s"decrypted state:\n$decrypted"); decode[T](decrypted).toTry}
+      result <- decode[T](decrypted).toTry
     } yield result
 
   def out[T](value: T, os: OutputStream)(implicit encoder: Encoder[T]): Try[Unit] = {


### PR DESCRIPTION
## Why are you doing this?
Add a CloudFormation policy to allow support-workers to access the KMS key


