### PR TITLE
FailureHandler was failing to handle failures

### DIFF
--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -56,7 +56,6 @@ trait ModelsCodecs { self: CustomCodecs with InternationalisationCodecs with Hel
 
   implicit val codecUser: Codec[User] = deriveCodec
   implicit val codecContribution: Codec[Contribution] = deriveCodec
-  implicit val codecErrorState: Codec[ErrorState] = deriveCodec
 }
 
 trait HelperCodecs {

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -16,12 +16,7 @@ class FailureHandler(emailService: EmailService)
     with LazyLogging {
   def this() = this(new EmailService(Configuration.emailServicesConfig.failed))
 
-  override protected def handlerFuture(state: FailureHandlerState, context: Context): Future[Unit] = {
-    logger.warn(s"FailureHandler called for error ${state.error.Error}")
-    sendEmail(state)
-  }
-
-  def sendEmail(state: FailureHandlerState): Future[Unit] = {
+  override protected def handlerFuture(state: FailureHandlerState, context: Context): Future[Unit] =
     emailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -30,5 +25,4 @@ class FailureHandler(emailService: EmailService)
       edition = state.user.country.alpha2,
       name = state.user.firstName
     )).map(_ => Unit)
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.5"
+  val supportModels = "com.gu" %% "support-models" % "0.6"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val awsLambdas = "com.amazonaws" % "aws-lambda-java-core" % "1.1.0"


### PR DESCRIPTION
## Why are you doing this?
Since we started wrapping the handler state to enable encryption, the error entity added to the input json by aws is now a level above the handler state so not available to the handler. Since we were only using it for logging anyway I've just removed the logging that was causing the problem.

