### PR TITLE
Check for an existing contribution subscription before creating a new one

### DIFF
--- a/cloud-formation/src/lambdas/createZuoraSubscriptionLambda.yaml
+++ b/cloud-formation/src/lambdas/createZuoraSubscriptionLambda.yaml
@@ -11,4 +11,4 @@ CreateZuoraSubscriptionLambda:
       S3Bucket: support-workers-dist
       S3Key: !Sub support/${Stage}/monthly-contributions/monthly-contributions.jar
     Runtime: "java8"
-    Timeout: "60"
+    Timeout: "240"

--- a/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -5,7 +5,7 @@ import com.gu.paypal.PayPalError
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
 import com.gu.stripe.Stripe
 import com.gu.support.workers.exceptions.RetryImplicits._
-import com.gu.zuora.model.ZuoraErrorResponse
+import com.gu.zuora.model.response.ZuoraErrorResponse
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/common/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/common/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -4,6 +4,7 @@ import cats.syntax.either._
 import com.gu.helpers.WebServiceHelper
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.zuora.model._
+import com.gu.zuora.model.response._
 import io.circe
 import io.circe.Decoder
 import io.circe.parser.decode
@@ -25,6 +26,14 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
 
   def getAccount(accountNumber: String): Future[GetAccountResponse] =
     get[GetAccountResponse](s"accounts/$accountNumber")
+
+  def getAccountIds(identityId: String): Future[QueryResponse] = {
+    val queryData = QueryData(s"select AccountNumber from account where IdentityId__c = '$identityId'")
+    post[QueryResponse](s"action/query", queryData.asJson)
+  }
+
+  def getSubscriptions(accountId: String): Future[SubscriptionsResponse] =
+    get[SubscriptionsResponse](s"subscriptions/accounts/$accountId")
 
   def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
     post[List[SubscribeResponseAccount]](s"action/subscribe", subscribeRequest.asJson)

--- a/common/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/common/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -1,11 +1,11 @@
 package com.gu.zuora
 
+import cats.implicits._
 import cats.syntax.either._
-import com.gu.config.Configuration
 import com.gu.helpers.WebServiceHelper
 import com.gu.okhttp.RequestRunners.FutureHttpClient
-import com.gu.zuora.model._
 import com.gu.zuora.model.response._
+import com.gu.zuora.model.{QueryData, SubscribeRequest}
 import io.circe
 import io.circe.Decoder
 import io.circe.parser.decode
@@ -28,37 +28,24 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
   def getAccount(accountNumber: String): Future[GetAccountResponse] =
     get[GetAccountResponse](s"accounts/$accountNumber")
 
-  def getAccountIds(identityId: String): Future[List[AccountRecord]] = {
+  def getAccountIds(identityId: String): Future[List[String]] = {
     val queryData = QueryData(s"select AccountNumber from account where IdentityId__c = '$identityId'")
-    post[QueryResponse](s"action/query", queryData.asJson).map(_.records)
+    post[QueryResponse](s"action/query", queryData.asJson).map(_.records.map(_.AccountNumber))
   }
 
-  def getSubscriptions(accountId: String): Future[SubscriptionsResponse] =
-    get[SubscriptionsResponse](s"subscriptions/accounts/$accountId")
+  def getSubscriptions(accountId: String): Future[List[Subscription]] =
+    get[SubscriptionsResponse](s"subscriptions/accounts/$accountId").map(_.subscriptions)
 
   def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
     post[List[SubscribeResponseAccount]](s"action/subscribe", subscribeRequest.asJson)
 
-  def userIsContributor(identityId: String): Future[Boolean] = {
-    val rp = for {
-      accounts <- getAccountIds(identityId)
-      subs <- accounts.map(getSubscriptions(i => i)
-      sub <- subs.subscriptions
-    } yield {
-      sub
-    }
-  }
+  def userIsContributor(identityId: String): Future[Boolean] =
+    for {
+      subs <- getAccountIds(identityId).flatMap(x => Future(x.map(getSubscriptions)))
+      flattened <- subs.combineAll
+      productRatePlanIds <- Future(flattened.flatMap(_.ratePlans.map(_.productRatePlanId)))
+    } yield productRatePlanIds.contains(config.productRatePlanId)
 
-//  def userIsContributor2(identityId: String): Any = {
-//    for
-//    getAccountIds(identityId).map {
-//      l =>
-//        l.map(a => getSubscriptions(a.AccountNumber)).map{
-//
-//        }
-//    }
-//
-//  }
 
   override def decodeError(responseBody: String)(implicit errorDecoder: Decoder[ZuoraErrorResponse]): Either[circe.Error, ZuoraErrorResponse] =
   //The Zuora api docs say that the subscribe action returns

--- a/common/src/main/scala/com/gu/zuora/model/QueryData.scala
+++ b/common/src/main/scala/com/gu/zuora/model/QueryData.scala
@@ -1,0 +1,10 @@
+package com.gu.zuora.model
+
+import com.gu.support.workers.encoding.Codec
+import com.gu.support.workers.encoding.Helpers.deriveCodec
+
+object QueryData {
+  implicit val codec: Codec[QueryData] = deriveCodec
+}
+
+case class QueryData(queryString: String)

--- a/common/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
@@ -1,0 +1,16 @@
+package com.gu.zuora.model.response
+
+import com.gu.support.workers.encoding.Codec
+import com.gu.support.workers.encoding.Helpers.deriveCodec
+
+object QueryResponse {
+  implicit val codec: Codec[QueryResponse] = deriveCodec
+}
+
+object AccountRecord {
+  implicit val codec: Codec[AccountRecord] = deriveCodec
+}
+
+case class QueryResponse(records : List[AccountRecord])
+
+case class AccountRecord(AccountNumber: String)

--- a/common/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
@@ -11,6 +11,6 @@ object AccountRecord {
   implicit val codec: Codec[AccountRecord] = deriveCodec
 }
 
-case class QueryResponse(records : List[AccountRecord])
+case class QueryResponse(records: List[AccountRecord])
 
 case class AccountRecord(AccountNumber: String)

--- a/common/src/main/scala/com/gu/zuora/model/response/Responses.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/Responses.scala
@@ -1,4 +1,4 @@
-package com.gu.zuora.model
+package com.gu.zuora.model.response
 
 import com.gu.support.workers.encoding.Codec
 import com.gu.support.workers.encoding.Helpers.{capitalizingCodec, deriveCodec}

--- a/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
@@ -21,4 +21,3 @@ case class Subscription(accountNumber: String, ratePlans: List[RatePlan])
 
 case class RatePlan(productId: String, productName: String, productRatePlanId: String)
 
-

--- a/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
@@ -1,0 +1,24 @@
+package com.gu.zuora.model.response
+
+import com.gu.support.workers.encoding.Codec
+import com.gu.support.workers.encoding.Helpers.deriveCodec
+
+object SubscriptionsResponse {
+  implicit val codec: Codec[SubscriptionsResponse] = deriveCodec
+}
+
+object Subscription {
+  implicit val codec: Codec[Subscription] = deriveCodec
+}
+
+object RatePlan {
+  implicit val codec: Codec[RatePlan] = deriveCodec
+}
+
+case class SubscriptionsResponse(subscriptions: List[Subscription])
+
+case class Subscription(ratePlans: List[RatePlan])
+
+case class RatePlan(productId: String, productName: String, productRatePlanId: String)
+
+

--- a/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
@@ -17,7 +17,7 @@ object RatePlan {
 
 case class SubscriptionsResponse(subscriptions: List[Subscription])
 
-case class Subscription(ratePlans: List[RatePlan])
+case class Subscription(accountNumber: String, ratePlans: List[RatePlan])
 
 case class RatePlan(productId: String, productName: String, productRatePlanId: String)
 

--- a/common/src/test/scala/com/gu/zuora/EncoderSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/EncoderSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.zuora
 
 import com.gu.zuora.encoding.CapitalizationEncoder._
-import com.gu.zuora.model.{Invoice, InvoiceResult}
+import com.gu.zuora.model.response.{Invoice, InvoiceResult}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
 import io.circe.syntax._

--- a/common/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/common/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -11,12 +11,12 @@ object Fixtures {
   val accountNumber = "A00069567"
 
   val getAccountResponse =
-    """
+    s"""
        {
          "basicInfo" : {
            "id" : "2c92c0f85bae511e015bcf31cde61532",
            "name" : "001g000001gPV73AAG",
-           "accountNumber" : "A00015760",
+           "accountNumber" : "$accountNumber",
            "notes" : null,
            "status" : "Active",
            "crmId" : "001g000001gPV73AAG",

--- a/common/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/common/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -8,7 +8,7 @@ import com.gu.zuora.model._
 import org.joda.time.LocalDate
 
 object Fixtures {
-  val accountNumber = "A00015760"
+  val accountNumber = "A00069567"
 
   val getAccountResponse =
     """

--- a/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
@@ -2,7 +2,7 @@ package com.gu.zuora
 
 import com.gu.zuora.Fixtures._
 import com.gu.zuora.encoding.CustomCodecs._
-import com.gu.zuora.model._
+import com.gu.zuora.model.response._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe
 import io.circe.parser._

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -4,7 +4,6 @@ import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.okhttp.RequestRunners
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
-import com.gu.zuora.model.response.Subscription
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -44,7 +43,7 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   it should "be able to find a monthly recurring subscription" in {
     uatService.getMonthlyRecurringSubscription("30000701").map {
-      response: Option[Subscription] =>
+      response =>
         response.isDefined should be(true)
         response.get.ratePlans.head.productName should be("Contributor")
     }

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -30,17 +30,21 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     }
   }
 
+  it should "be resistant to 'ZOQL injection'" in {
+    a[NumberFormatException] should  be thrownBy uatService.getAccountIds("30000701' or status = 'Active")
+  }
+
   it should "retrieve subscriptions from an account id" in {
     uatService.getSubscriptions("A00069602").map {
       response =>
         response.nonEmpty should be(true)
-        response.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
+        response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).productRatePlanId)
     }
   }
 
   it should "be able to find a monthly recurring subscription" in {
     uatService.getMonthlyRecurringSubscription("30000701").map {
-      response : Option[Subscription] =>
+      response: Option[Subscription] =>
         response.isDefined should be(true)
         response.get.ratePlans.head.productName should be("Contributor")
     }

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -27,11 +27,11 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     uatService.getAccountIds("30000701").map {
       response =>
         logger.info(s"$response")
-        response.records.nonEmpty should be(true)
+        response.nonEmpty should be(true)
     }
   }
 
-  it should "retrieve subscriptions from and account id" in {
+  it should "retrieve subscriptions from an account id" in {
     uatService.getSubscriptions("A00069602").map {
       response =>
         logger.info(s"$response")
@@ -39,6 +39,15 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
         response.subscriptions.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
     }
   }
+
+//  it should "find out whether a user is a contributor" in {
+//    uatService.userIsContributor("30000701").map {
+//      response =>
+//        logger.info(s"$response")
+//        response.subscriptions.nonEmpty should be(true)
+//        response.subscriptions.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
+//    }
+//  }
 
   "Subscribe request" should "succeed" in {
     val zuoraService = new ZuoraService(zuoraConfigProvider.get(), RequestRunners.configurableFutureRunner(30.seconds))

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -18,7 +18,6 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
   "ZuoraService" should "retrieve an account" in {
     uatService.getAccount(Fixtures.accountNumber).map {
       response =>
-        logger.info(s"$response")
         response.success should be(true)
         response.basicInfo.accountNumber should be(Fixtures.accountNumber)
     }
@@ -27,7 +26,6 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
   it should "retrieve account ids from an Identity id" in {
     uatService.getAccountIds("30000701").map {
       response =>
-        logger.info(s"$response")
         response.nonEmpty should be(true)
     }
   }
@@ -35,7 +33,6 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
   it should "retrieve subscriptions from an account id" in {
     uatService.getSubscriptions("A00069602").map {
       response =>
-        logger.info(s"$response")
         response.nonEmpty should be(true)
         response.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
     }
@@ -44,7 +41,6 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
   it should "be able to find a monthly recurring subscription" in {
     uatService.getMonthlyRecurringSubscription("30000701").map {
       response : Option[Subscription] =>
-        logger.info(s"$response")
         response.isDefined should be(true)
         response.get.ratePlans.head.productName should be("Contributor")
     }

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -35,19 +35,18 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     uatService.getSubscriptions("A00069602").map {
       response =>
         logger.info(s"$response")
-        response.subscriptions.nonEmpty should be(true)
-        response.subscriptions.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
+        response.nonEmpty should be(true)
+        response.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
     }
   }
 
-//  it should "find out whether a user is a contributor" in {
-//    uatService.userIsContributor("30000701").map {
-//      response =>
-//        logger.info(s"$response")
-//        response.subscriptions.nonEmpty should be(true)
-//        response.subscriptions.head.ratePlans.head.productRatePlanId should be (zuoraConfigProvider.get(true).productRatePlanId)
-//    }
-//  }
+  it should "find out whether a user is a contributor" in {
+    uatService.userIsContributor("30000701").map {
+      response : Boolean =>
+        logger.info(s"$response")
+        response should be(true)
+    }
+  }
 
   "Subscribe request" should "succeed" in {
     val zuoraService = new ZuoraService(zuoraConfigProvider.get(), RequestRunners.configurableFutureRunner(30.seconds))

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -4,6 +4,7 @@ import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.okhttp.RequestRunners
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
+import com.gu.zuora.model.response.Subscription
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -40,11 +41,12 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     }
   }
 
-  it should "find out whether a user is a contributor" in {
-    uatService.userIsContributor("30000701").map {
-      response : Boolean =>
+  it should "be able to find a monthly recurring subscription" in {
+    uatService.getMonthlyRecurringSubscription("30000701").map {
+      response : Option[Subscription] =>
         logger.info(s"$response")
-        response should be(true)
+        response.isDefined should be(true)
+        response.get.ratePlans.head.productName should be("Contributor")
     }
   }
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvider)
-  extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider)
+    extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider)
     with LazyLogging {
 
   def this() = this(ServiceProvider)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -12,7 +12,7 @@ import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures.{incorrectPaymentMethod, invalidSubscriptionRequest}
 import com.gu.zuora.ZuoraService
-import com.gu.zuora.model.ZuoraErrorResponse
+import com.gu.zuora.model.response.ZuoraErrorResponse
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.RecoverMethods
 


### PR DESCRIPTION
## Why are you doing this?

The subscribe call to Zuora is not idempotent and it is possible for the request to time out (from the point of view of the step functions) whilst actually still succeeding in Zuora. This would result in us retrying and potentially creating multiple live subscriptions.

To get around this problem I have introduced a check to the CreateZuoraSubscription lambda so that if an existing monthly recurring subscription exists for the current user then we skip the account creation step and just move on to the next step in the monthly contribution flow.

[**Trello Card**](https://trello.com/c/1i1MhfIh/615-q2-test-2-check-for-existing-monthly-contribution-before-attempting-zuora-subscribe-call)

