### PR TITLE
Add cloudwatch:putMetricData permission to the Lambda execution role

### DIFF
--- a/cloud-formation/src/cfn-template.yaml
+++ b/cloud-formation/src/cfn-template.yaml
@@ -61,6 +61,7 @@ Resources:
                 - logs:Create*
                 - logs:PutLogEvents
                 - logs:DescribeLogStreams
+                - cloudwatch:putMetricData
               Resource: arn:aws:logs:*:*:*
         - PolicyName: KMSEncryption
           PolicyDocument:


### PR DESCRIPTION
## Why are you doing this?

Lambdas don't currently have the cloudwatch:putMetricData permission which is causing failures
