### PR TITLE
Fix stripe error parsing

### DIFF
--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -2,15 +2,20 @@ package com.gu.stripe
 
 import com.gu.support.workers.encoding.Codec
 import com.gu.support.workers.encoding.Helpers.deriveCodec
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import com.gu.support.workers.exceptions.{RetryException, RetryLimited, RetryNone, RetryUnlimited}
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, Json}
 
 object Stripe {
 
   sealed trait StripeObject
 
   object StripeError {
-    implicit val codec: Codec[StripeError] = deriveCodec
+    private val encoder = deriveEncoder[StripeError].mapJson { json => Json.fromFields(List("error" -> json)) }
+    
+    private val decoder = deriveDecoder[StripeError].prepare { _.downField("error") }
+
+    implicit val codec: Codec[StripeError] = new Codec[StripeError](encoder, decoder)
   }
 
   //See docs here: https://stripe.com/docs/api/curl#errors

--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -22,12 +22,13 @@ object Stripe {
   case class StripeError(
       `type`: String, //The type of error: api_connection_error, api_error, authentication_error, card_error, invalid_request_error, or rate_limit_error
       message: String, //A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
-      code: String = "", //For card errors, a short string from amongst those listed on the right describing the kind of card error that occurred.
-      decline_code: String = "", //For card errors resulting from a bank decline, a short string indicating the bank's reason for the decline.
-      param: String = "" //The parameter the error relates to if the error is parameter-specific..
+      code: Option[String] = None, //For card errors, a short string from amongst those listed on the right describing the kind of card error that occurred.
+      decline_code: Option[String] = None, //For card errors resulting from a bank decline, a short string indicating the bank's reason for the decline.
+      param: Option[String] = None //The parameter the error relates to if the error is parameter-specific..
   ) extends Throwable with StripeObject {
 
-    override def getMessage: String = s"message: $message; type: ${`type`}; code: $code; decline_code: $decline_code; param: $param"
+    override def getMessage: String =
+      s"message: $message; type: ${`type`}; code: ${code.getOrElse("")}; decline_code: ${decline_code.getOrElse("")}; param: ${param.getOrElse("")}"
 
     def asRetryException: RetryException = `type` match {
       case "api_connection_error" | "api_error" | "rate_limit_error" => new RetryUnlimited(cause = this)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/CirceEncodingBehaviourSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/CirceEncodingBehaviourSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.support.workers
 
+import com.gu.stripe.Stripe.StripeError
 import com.gu.support.workers.model.{PayPalReferenceTransaction, PaymentMethod}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
@@ -75,5 +76,18 @@ class CirceEncodingBehaviourSpec extends FlatSpec with Matchers with LazyLogging
     val json = pprt.asJson
     val pprt2 = decode[PaymentMethod](json.noSpaces)
     pprt2.isRight should be(true) //decoding succeeded
+  }
+
+  it should "be able to decode a stripe error" in {
+    val json = """
+      |{
+      |  "error": {
+      |    "type": "invalid_request_error",
+      |    "message": "You cannot use a Stripe token more than once: tok_IRqAu50hjXnumI."
+      |  }
+      |}""".stripMargin
+    val decoded = decode[StripeError](json)
+    decoded.isRight should be(true)
+    decoded.right.map(_.`type`) should be(Right("invalid_request_error"))
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -44,7 +44,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
   }
 
   "402s from Stripe" should "throw a FatalException" in {
-    val errorJson = Stripe.StripeError("card_error", "The card has expired", "expired_card").asJson.noSpaces
+    val errorJson = Stripe.StripeError("card_error", "The card has expired", Some("expired_card")).asJson.noSpaces
     val server = createMockServer(402, errorJson)
     val baseUrl = server.url("/v1")
 


### PR DESCRIPTION
Stripe errors were not being parsed correctly, so the default RetryUnlimited was being applied to all stripe errors.

I've tested this change on CODE, and it correctly fails immediately for invalid_request_error.
