### PR TITLE
Fix for American Express

### DIFF
--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -49,6 +49,9 @@ object Stripe {
 
   case class Card(id: String, `type`: String, last4: String, exp_month: Int, exp_year: Int, country: String) extends StripeObject {
     val issuer = `type`.toLowerCase
+    // Zuora requires 'AmericanExpress' not 'American Express'
+    // See CreditCardType at https://www.zuora.com/developer/api-reference/#operation/Object_POSTPaymentMethod
+    val zuoraCardType = `type`.replaceAll(" ", "")
   }
 
   object Customer {

--- a/common/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/common/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -104,7 +104,7 @@ object Fixtures {
 
   val account = Account(salesforceAccountId, GBP, salesforceAccountId, salesforceId, identityId, StripeGateway)
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", "test@gu.com", Country.UK)
-  val creditCardPaymentMethod = CreditCardReferenceTransaction(tokenId, secondTokenId, cardNumber, Some(Country.UK), 12, 22, "Visa")
+  val creditCardPaymentMethod = CreditCardReferenceTransaction(tokenId, secondTokenId, cardNumber, Some(Country.UK), 12, 22, "AmericanExpress")
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
 
   val config = Configuration.zuoraConfigProvider.get()

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -50,8 +50,9 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       .createCustomer(stripe.userId, stripe.stripeToken)
       .map { stripeCustomer =>
         val card = stripeCustomer.card
+        val zuoraCardType = card.`type`.replaceAll(" ", "") // Zuora requires 'AmericanExpress' not 'American Express'
         CreditCardReferenceTransaction(card.id, stripeCustomer.id, card.last4,
-          CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, card.`type`)
+          CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, zuoraCardType)
       }
 
   def createPayPalPaymentMethod(payPal: PayPalPaymentFields, payPalService: PayPalService): Future[PayPalReferenceTransaction] =

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -50,9 +50,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       .createCustomer(stripe.userId, stripe.stripeToken)
       .map { stripeCustomer =>
         val card = stripeCustomer.card
-        val zuoraCardType = card.`type`.replaceAll(" ", "") // Zuora requires 'AmericanExpress' not 'American Express'
         CreditCardReferenceTransaction(card.id, stripeCustomer.id, card.last4,
-          CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, zuoraCardType)
+          CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, card.zuoraCardType)
       }
 
   def createPayPalPaymentMethod(payPal: PayPalPaymentFields, payPalService: PayPalService): Future[PayPalReferenceTransaction] =


### PR DESCRIPTION
## Why are you doing this?

The monthly contributions flow currently fails if the user attempts to pay with American Express, because Zuora requires the card type to be sent as 'AmericanExpress', not 'American Express'.

See also:
https://github.com/guardian/membership-common/pull/371

[**Trello Card**](https://trello.com/c/lrELOTgh/810-fix-american-express)

## Changes

* Remove whitespace when creating CreditCardReferenceTransaction for Zuora

cc @davidfurey @rupertbates 