### PR TITLE
Annual contributions

### DIFF
--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -32,11 +32,15 @@ touchpoint.backend.environments {
         username=""
         password=""
       }
-      productRatePlanIds {
-        contribution = ""
-      }
-      productRatePlanChargeIds {
-        contribution = ""
+      contribution {
+        monthly {
+          productRatePlanId=""
+          productRatePlanChargeId=""
+        }
+        annual {
+          productRatePlanId=""
+          productRatePlanChargeId=""
+        }
       }
     }
   }

--- a/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
+++ b/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
@@ -1,16 +1,36 @@
 package com.gu.zuora
 
 import com.gu.support.config.{Stage, TouchpointConfig, TouchpointConfigProvider}
+import com.gu.support.workers.model.{Annual, BillingPeriod}
 import com.typesafe.config.Config
 
-case class ZuoraConfig(url: String, username: String, password: String, productRatePlanId: String, productRatePlanChargeId: String) extends TouchpointConfig
+case class ZuoraContributionConfig(productRatePlanId: String, productRatePlanChargeId: String)
+
+case class ZuoraConfig(
+  url: String,
+  username: String,
+  password: String,
+  monthlyContribution: ZuoraContributionConfig,
+  annualContribution: ZuoraContributionConfig)
+  extends TouchpointConfig {
+  def configForBillingPeriod(billingPeriod: BillingPeriod): ZuoraContributionConfig =
+    billingPeriod match {
+      case _: Annual.type => annualContribution
+      case _ => monthlyContribution
+    }
+}
 
 class ZuoraConfigProvider(config: Config, defaultStage: Stage) extends TouchpointConfigProvider[ZuoraConfig](config, defaultStage) {
   def fromConfig(config: Config): ZuoraConfig = ZuoraConfig(
     url = config.getString(s"zuora.api.url"),
     username = config.getString(s"zuora.api.username"),
     password = config.getString(s"zuora.api.password"),
-    productRatePlanId = config.getString(s"zuora.productRatePlanIds.contribution"),
-    productRatePlanChargeId = config.getString(s"zuora.productRatePlanChargeIds.contribution")
+    monthlyContribution = contributionFromConfig(config.getConfig("zuora.contribution.monthly")),
+    annualContribution = contributionFromConfig(config.getConfig("zuora.contribution.annual"))
+  )
+
+  private def contributionFromConfig(config: Config): ZuoraContributionConfig = ZuoraContributionConfig(
+    productRatePlanId = config.getString("productRatePlanId"),
+    productRatePlanChargeId = config.getString("productRatePlanChargeId")
   )
 }

--- a/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
+++ b/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
@@ -15,7 +15,7 @@ case class ZuoraConfig(
   extends TouchpointConfig {
   def configForBillingPeriod(billingPeriod: BillingPeriod): ZuoraContributionConfig =
     billingPeriod match {
-      case _: Annual.type => annualContribution
+      case Annual => annualContribution
       case _ => monthlyContribution
     }
 }

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -15,7 +15,8 @@ import org.joda.time.{DateTime, LocalDate}
 
 import scala.util.Try
 
-object CustomCodecs extends CustomCodecs with ModelsCodecs with InternationalisationCodecs with HelperCodecs
+
+object CustomCodecs extends CustomCodecs with InternationalisationCodecs with ModelsCodecs with HelperCodecs
 
 trait InternationalisationCodecs {
   implicit val encodeCurrency: Encoder[Currency] = Encoder.encodeString.contramap[Currency](_.iso)
@@ -28,7 +29,8 @@ trait InternationalisationCodecs {
     Decoder.decodeString.emap { code => CountryGroup.countryByCode(code).toRight(s"Unrecognised country code '$code'") }
 }
 
-trait ModelsCodecs { self: CustomCodecs with InternationalisationCodecs with HelperCodecs =>
+trait ModelsCodecs {
+  self: CustomCodecs with InternationalisationCodecs with HelperCodecs =>
   type PaymentFields = Either[StripePaymentFields, PayPalPaymentFields]
 
   implicit val codecPayPalReferenceTransaction: Codec[PayPalReferenceTransaction] = capitalizingCodec
@@ -55,13 +57,17 @@ trait ModelsCodecs { self: CustomCodecs with InternationalisationCodecs with Hel
   }
 
   implicit val decodePeriod: Decoder[BillingPeriod] =
-    Decoder.decodeString.emap{code => BillingPeriod.fromString(code).toRight(s"Unrecognised period code '$code'")}
-
+    Decoder.decodeString.emap(code => BillingPeriod.fromString(code).toRight(s"Unrecognised period code '$code'"))
   implicit val encodePeriod: Encoder[BillingPeriod] = Encoder.encodeString.contramap[BillingPeriod](_.toString)
 
-
   implicit val codecUser: Codec[User] = deriveCodec
-  implicit val codecContribution: Codec[Contribution] = deriveCodec
+
+  //There is a configuration option in Circe to allow the use of Scala default parameters, but unfortunately
+  //it doesn't seem to work in version 0.8.0 so we'll have to use this more verbose approach
+  implicit val decodeContribution: Decoder[Contribution] = Decoder
+    .forProduct3("amount", "currency", "billingPeriod")(Contribution.apply)
+    .or(Decoder.forProduct2("amount", "currency")((a: BigDecimal, c: Currency) => Contribution(a, c)))
+  implicit val encodeContribution: Encoder[Contribution] = deriveEncoder
 }
 
 trait HelperCodecs {
@@ -69,10 +75,8 @@ trait HelperCodecs {
   implicit val decodeLocalTime: Decoder[LocalDate] = Decoder.decodeString.map(LocalDate.parse)
   implicit val encodeDateTime: Encoder[DateTime] = Encoder.encodeLong.contramap(_.getMillis)
   implicit val decodeDateTime: Decoder[DateTime] = Decoder.decodeLong.map(new DateTime(_))
-  implicit val uuidDecoder: Decoder[UUID] =
-    Decoder.decodeString.emap { code => Try { UUID.fromString(code) }.toOption.toRight(s"Invalid UUID '$code'") }
-
-  implicit val uuidEnecoder: Encoder[UUID] = Encoder.encodeString.contramap(_.toString)
+  implicit val uuidDecoder: Decoder[UUID] = Decoder.decodeString.emap(code => Try(UUID.fromString(code)).toOption.toRight(s"Invalid UUID '$code'"))
+  implicit val uuidEncoder: Encoder[UUID] = Encoder.encodeString.contramap(_.toString)
 }
 
 trait CustomCodecs {

--- a/common/src/main/scala/com/gu/zuora/model/response/Responses.scala
+++ b/common/src/main/scala/com/gu/zuora/model/response/Responses.scala
@@ -1,11 +1,11 @@
 package com.gu.zuora.model.response
 
-import com.gu.support.workers.encoding.{Codec, ErrorJson}
-import com.gu.support.workers.encoding.Helpers.{capitalizingCodec, deriveCodec}
-import com.gu.support.workers.exceptions.{RetryException, RetryNone}
-import io.circe.syntax._
-import io.circe.parser._
 import cats.implicits._
+import com.gu.support.workers.encoding.Helpers.{capitalizingCodec, deriveCodec}
+import com.gu.support.workers.encoding.{Codec, ErrorJson}
+import com.gu.support.workers.exceptions.{RetryException, RetryNone}
+import io.circe.parser._
+import io.circe.syntax._
 
 sealed trait ZuoraResponse {
   def success: Boolean
@@ -72,7 +72,7 @@ case class SubscribeResponseAccount(
   invoiceResult: InvoiceResult,
   totalTcv: Int,
   subscriptionId: String,
-  totalMrr: Int,
+  totalMrr: Float,
   paymentTransactionNumber: String,
   accountId: String,
   gatewayResponseCode: String,

--- a/common/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/common/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -1,7 +1,7 @@
 package com.gu.salesforce
 
 object Fixtures {
-  val idId = "30000270"
+  val idId = "30000264"
   val salesforceId = "003g000001UnFItAAN"
   val email = "6cwdm8aler7z9r6nwbc@gu.com"
   val name = "6cWdM8AlER7z9R6nWBc"

--- a/common/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/common/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -1,7 +1,7 @@
 package com.gu.salesforce
 
 object Fixtures {
-  val idId = "30000264"
+  val idId = "30000270"
   val salesforceId = "003g000001UnFItAAN"
   val email = "6cwdm8aler7z9r6nwbc@gu.com"
   val name = "6cWdM8AlER7z9R6nWBc"

--- a/common/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/common/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -7,6 +7,7 @@ import com.gu.support.workers.model.{CreditCardReferenceTransaction, PayPalRefer
 import com.gu.zuora.model._
 import org.joda.time.LocalDate
 
+//noinspection TypeAnnotation
 object Fixtures {
   val accountNumber = "A00069567"
 
@@ -108,12 +109,12 @@ object Fixtures {
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
 
   val config = Configuration.zuoraConfigProvider.get()
-  val subscriptionData = SubscriptionData(
+  val monthlySubscriptionData = SubscriptionData(
     List(
       RatePlanData(
-        RatePlan(config.productRatePlanId), //Contribution product
+        RatePlan(config.monthlyContribution.productRatePlanId), //Contribution product
         List(RatePlanChargeData(
-          RatePlanCharge(config.productRatePlanChargeId, Some(25: BigDecimal))
+          RatePlanCharge(config.monthlyContribution.productRatePlanChargeId, Some(25: BigDecimal))
         )),
         Nil
       )
@@ -121,27 +122,31 @@ object Fixtures {
     Subscription(date, date, date)
   )
 
-  val subscriptionRequest = SubscribeRequest(List(SubscribeItem(account, contactDetails, creditCardPaymentMethod, subscriptionData, SubscribeOptions())))
+  val subscriptionRequest = SubscribeRequest(List(SubscribeItem(account, contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())))
 
   val usAccount = Account(salesforceAccountId, USD, salesforceAccountId, salesforceId, identityId, StripeGateway)
 
-  val usSubscriptionRequest = SubscribeRequest(List(SubscribeItem(usAccount, contactDetails, creditCardPaymentMethod, subscriptionData, SubscribeOptions())))
+  val usSubscriptionRequest = SubscribeRequest(List(
+    SubscribeItem(usAccount, contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())
+  ))
 
-  val invalidSubsData = SubscriptionData(
+  val invalidMonthlySubsData = SubscriptionData(
     List(
       RatePlanData(
-        RatePlan(config.productRatePlanId),
+        RatePlan(config.monthlyContribution.productRatePlanId),
         List(RatePlanChargeData(
-          RatePlanCharge(config.productRatePlanChargeId, Some(5: BigDecimal))
+          RatePlanCharge(config.monthlyContribution.productRatePlanChargeId, Some(5: BigDecimal))
         )),
         Nil
       )
     ),
     Subscription(date, date, date, termType = "Invalid term type")
   )
-  val invalidSubscriptionRequest = SubscribeRequest(List(SubscribeItem(account, contactDetails, creditCardPaymentMethod, invalidSubsData, SubscribeOptions())))
+  val invalidSubscriptionRequest = SubscribeRequest(List(
+    SubscribeItem(account, contactDetails, creditCardPaymentMethod, invalidMonthlySubsData, SubscribeOptions())
+  ))
 
-  val incorrectPaymentMethod = SubscribeRequest(List(SubscribeItem(account, contactDetails, payPalPaymentMethod, invalidSubsData, SubscribeOptions())))
+  val incorrectPaymentMethod = SubscribeRequest(List(SubscribeItem(account, contactDetails, payPalPaymentMethod, invalidMonthlySubsData, SubscribeOptions())))
 
   val invoiceResult =
     """
@@ -180,7 +185,34 @@ object Fixtures {
         $subscribeResponseAccount
       ]
     """
-
+ val subscribeResponseAnnual =
+   """
+     [
+        {
+          "AccountNumber": "A00016540",
+          "SubscriptionNumber": "A-S00043802",
+          "GatewayResponse": "Approved",
+          "PaymentId": "2c92c0f95e1d5ca3015e38e585f339dc",
+          "InvoiceResult": {
+            "Invoice": [
+              {
+                "InvoiceNumber": "INV00052447",
+                "Id": "2c92c0f95e1d5ca3015e38e585b539d1"
+              }
+            ]
+          },
+          "TotalTcv": 150,
+          "SubscriptionId": "2c92c0f95e1d5ca3015e38e5854739c3",
+          "Success": true,
+          "TotalMrr": 12.5,
+          "PaymentTransactionNumber": "18X93788F8464761C",
+          "AccountId": "2c92c0f95e1d5ca3015e38e583c739bd",
+          "GatewayResponseCode": "Approved",
+          "InvoiceNumber": "INV00052447",
+          "InvoiceId": "2c92c0f95e1d5ca3015e38e585b539d1"
+        }
+      ]
+   """
   val error =
     """
       {

--- a/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
@@ -38,7 +38,7 @@ class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
   }
 
   "SubscribeResponse" should "deserialise correctly" in {
-    val decodeResponse = decode[List[SubscribeResponseAccount]](subscribeResponse)
+    val decodeResponse = decode[List[SubscribeResponseAccount]](subscribeResponseAnnual)
     decodeResponse.isRight should be(true)
   }
 

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -2,6 +2,7 @@ package com.gu.zuora
 
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.okhttp.RequestRunners
+import com.gu.support.workers.model.Monthly
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
 import com.gu.zuora.model.response.ZuoraErrorResponse
@@ -38,12 +39,12 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     uatService.getSubscriptions("A00069602").map {
       response =>
         response.nonEmpty should be(true)
-        response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).productRatePlanId)
+        response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).monthlyContribution.productRatePlanId)
     }
   }
 
   it should "be able to find a monthly recurring subscription" in {
-    uatService.getMonthlyRecurringSubscription("30000701").map {
+    uatService.getRecurringSubscription("30000701", Monthly).map {
       response =>
         response.isDefined should be(true)
         response.get.ratePlans.head.productName should be("Contributor")

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -27,7 +27,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     }
 
   def skipSubscribe(state: CreateZuoraSubscriptionState, subscription: SubscriptionResponse): Future[SendThankYouEmailState] = {
-    logger.info(s"Skipping subscribe for user ${state.user.id} because they are already a contributor " +
+    logger.info(s"Skipping subscribe for user because they are already a contributor " +
       s"with account number ${subscription.accountNumber}")
     Future.successful(getEmailState(state, subscription.accountNumber))
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/DefaultBillingPeriodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/DefaultBillingPeriodSpec.scala
@@ -1,0 +1,25 @@
+package com.gu.support.workers
+
+import com.gu.support.workers.Fixtures.{annualContributionJson, monthlyContributionJson}
+import com.gu.support.workers.model.monthlyContributions.Contribution
+import com.gu.support.workers.model.{Annual, Monthly}
+import com.gu.zuora.encoding.CustomCodecs.{decodeContribution, decodeCurrency, decodePeriod}
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.parser.decode
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+class DefaultBillingPeriodSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
+
+  "Contribution JSON with no billing period set" should "default to Monthly" in {
+    val contribution = decode[Contribution](monthlyContributionJson)
+    contribution.isRight should be(true)
+    contribution.right.get.billingPeriod should be(Monthly)
+  }
+
+  "Contribution JSON with a billing period set" should "be decoded correctly" in {
+    val contribution = decode[Contribution](annualContributionJson)
+    contribution.isRight should be(true)
+    contribution.right.get.billingPeriod should be(Annual)
+  }
+}

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -39,7 +39,16 @@ object Fixtures {
          }
        """
 
-  val contributionJson =
+  val annualContributionJson =
+    """
+      {
+        "amount": 60,
+        "currency": "GBP",
+        "billingPeriod": "Annual"
+      }
+    """
+
+  val monthlyContributionJson =
     """
       {
         "amount": 5,
@@ -67,15 +76,23 @@ object Fixtures {
     s"""{
           $requestIdJson,
           $userJson,
-          "contribution": $contributionJson,
+          "contribution": $monthlyContributionJson,
           "paymentFields": $payPalJson
         }"""
 
-  val createStripePaymentMethodJson =
+  val createMonthlyStripeJson =
     s"""{
           $requestIdJson,
           $userJson,
-          "contribution": $contributionJson,
+          "contribution": $monthlyContributionJson,
+          "paymentFields": $stripeJson
+        }"""
+
+  val createAnnualStripeJson =
+    s"""{
+          $requestIdJson,
+          $userJson,
+          "contribution": $annualContributionJson,
           "paymentFields": $stripeJson
         }"""
 
@@ -84,7 +101,7 @@ object Fixtures {
           {
             $requestIdJson,
             $userJson,
-            "contribution": $contributionJson,
+            "contribution": $monthlyContributionJson,
             "paymentMethod": $payPalPaymentMethod
           }
         """
@@ -93,7 +110,7 @@ object Fixtures {
     s"""{
        |  $requestIdJson,
        |  $userJson,
-       |  "contribution": $contributionJson,
+       |  "contribution": $monthlyContributionJson,
        |  "paymentMethod": $payPalPaymentMethod,
        |  "salesForceContact": {
        |    "Id": "123",
@@ -122,7 +139,7 @@ object Fixtures {
           {
             $requestIdJson,
             $userJson,
-            "contribution": $contributionJson,
+            "contribution": $monthlyContributionJson,
             "paymentMethod": $payPalPaymentMethod,
             "salesForceContact": $salesforceContactJson
             }
@@ -138,7 +155,7 @@ object Fixtures {
     s"""{
        |  $requestIdJson,
        |  $userJson,
-       |  "contribution": $contributionJson,
+       |  "contribution": $monthlyContributionJson,
        |  "error": {
        |    "Error": "com.gu.support.workers.exceptions.ErrorHandler.logAndRethrow(ErrorHandler.scala:33)",
        |    "Cause": "The card has expired"

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -8,6 +8,7 @@ import com.gu.support.workers.encoding.Wrapper
 import com.gu.support.workers.encoding.Wrapper.jsonCodec
 import io.circe.syntax._
 
+//noinspection TypeAnnotation
 object Fixtures {
   def wrapFixture(string: String): ByteArrayInputStream = Wrapper.wrapString(string).asJson.noSpaces.asInputStream
 
@@ -42,7 +43,8 @@ object Fixtures {
     """
       {
         "amount": 5,
-        "currency": "GBP"
+        "currency": "GBP",
+        "billingPeriod": "Monthly"
       }
     """
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -42,7 +42,7 @@ object Fixtures {
   val annualContributionJson =
     """
       {
-        "amount": 60,
+        "amount": 150,
         "currency": "GBP",
         "billingPeriod": "Annual"
       }
@@ -134,12 +134,23 @@ object Fixtures {
           "AccountId": "001g000001gOR06AAG"
         }
       """
-  val createZuoraSubscriptionJson =
+  val createMonthlyZuoraSubscriptionJson =
     s"""
           {
             $requestIdJson,
             $userJson,
             "contribution": $monthlyContributionJson,
+            "paymentMethod": $payPalPaymentMethod,
+            "salesForceContact": $salesforceContactJson
+            }
+        """
+
+  val createAnnualZuoraSubscriptionJson =
+    s"""
+          {
+            $requestIdJson,
+            $userJson,
+            "contribution": $annualContributionJson,
             "paymentMethod": $payPalPaymentMethod,
             "salesForceContact": $salesforceContactJson
             }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -52,8 +52,7 @@ object Fixtures {
     """
       {
         "amount": 5,
-        "currency": "GBP",
-        "billingPeriod": "Monthly"
+        "currency": "GBP"
       }
     """
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers
 import com.gu.support.workers.Fixtures.{monthlyContributionJson, wrapFixture}
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.zuora.encoding.CustomCodecs.codecContribution
+import com.gu.zuora.encoding.CustomCodecs._
 import org.scalatest.{FlatSpec, Matchers}
 
 class WrapperSpec extends FlatSpec with Matchers {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.support.workers
 
-import com.gu.support.workers.Fixtures.{contributionJson, wrapFixture}
+import com.gu.support.workers.Fixtures.{monthlyContributionJson, wrapFixture}
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.zuora.encoding.CustomCodecs.codecContribution
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class WrapperSpec extends FlatSpec with Matchers {
   "Wrapper" should "be able to round trip some json" in {
-    val wrapped = wrapFixture(contributionJson)
+    val wrapped = wrapFixture(monthlyContributionJson)
 
     val contribution = Encoding.in[Contribution](wrapped)
     contribution.isSuccess should be(true)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -6,7 +6,7 @@ import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
 import com.gu.stripe.{Stripe, StripeService}
-import com.gu.support.workers.Fixtures.{createStripePaymentMethodJson, wrapFixture}
+import com.gu.support.workers.Fixtures.{createMonthlyStripeJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.{RetryNone, RetryUnlimited}
 import com.gu.support.workers.lambdas.CreatePaymentMethod
@@ -22,7 +22,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createMonthlyStripeJson), outStream, context)
     }
   }
 
@@ -36,7 +36,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createMonthlyStripeJson), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.
@@ -55,13 +55,13 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryNone] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createMonthlyStripeJson), outStream, context)
     }
 
     server.shutdown()
   }
 
-  lazy val timeoutServices = mockServices(
+  private lazy val timeoutServices = mockServices(
     s => s.stripeService,
     //Create a stripe service which will timeout after 1 millisecond
     new StripeService(Configuration.stripeConfigProvider.get(), configurableFutureRunner(1.milliseconds))

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
-import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrapFixture}
+import com.gu.support.workers.Fixtures.{createMonthlyZuoraSubscriptionJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
@@ -45,7 +45,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val createZuoraSubscription = new CreateZuoraSubscription(timeoutServices)
     val outputStream = new ByteArrayOutputStream()
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson), outputStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createMonthlyZuoraSubscriptionJson), outputStream, context)
     }
   }
 
@@ -59,13 +59,13 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson), outStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createMonthlyZuoraSubscriptionJson), outStream, context)
     }
 
     server.shutdown()
   }
 
-  val timeoutServices = errorServices(None, 1.milliseconds)
+  private val timeoutServices = errorServices(None, 1.milliseconds)
 
   def errorServices(baseUrl: Option[String], timeout: Duration = 10.seconds): ServiceProvider = mockServices(
     s => s.zuoraService,

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -14,12 +14,23 @@ import com.gu.test.tags.annotations.IntegrationTest
 @IntegrationTest
 class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
-  "CreateZuoraSubscription lambda" should "create a Zuora subscription" in {
+  "CreateZuoraSubscription lambda" should "create a monthly Zuora subscription" in {
     val createZuora = new CreateZuoraSubscription()
 
     val outStream = new ByteArrayOutputStream()
 
-    createZuora.handleRequest(wrapFixture(createZuoraSubscriptionJson), outStream, context)
+    createZuora.handleRequest(wrapFixture(createMonthlyZuoraSubscriptionJson), outStream, context)
+
+    val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
+    sendThankYouEmail._1.accountNumber.length should be > 0
+  }
+
+  "CreateZuoraSubscription lambda" should "create an annual Zuora subscription" in {
+    val createZuora = new CreateZuoraSubscription()
+
+    val outStream = new ByteArrayOutputStream()
+
+    createZuora.handleRequest(wrapFixture(createAnnualZuoraSubscriptionJson), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
     sendThankYouEmail._1.accountNumber.length should be > 0

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -49,7 +49,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodJson), outStream, context)
+    createPaymentMethod.handleRequest(wrapFixture(createMonthlyStripeJson), outStream, context)
 
     //Check the output
     val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
@@ -76,7 +76,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
     }
   }
 
-  lazy val mockServices = {
+  private lazy val mockServices = {
     //Mock the stripe service as we cannot actually create a customer
     val serviceProvider = mock[ServiceProvider]
     val services = mock[Services]

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.lambdas
 import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.monthlyContributions.state.CreatePaymentMethodState
-import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields}
+import com.gu.support.workers.model.{Annual, Monthly, PayPalPaymentFields, StripePaymentFields}
 import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser._
@@ -12,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
 
-  "CreatePaymentMethodStateDecoder" should "be able to decode a CreatePaymentMethodStateDecoder with PayPal payment fields" in {
+  "CreatePaymentMethodStateDecoder" should "be able to decode a monthly contribution with PayPal payment fields" in {
     val state = decode[CreatePaymentMethodState](createPayPalPaymentMethodJson)
     val result = state.right.get
     result.contribution.amount should be(5)
@@ -20,10 +20,20 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
     result.paymentFields.right.get.baid should be(validBaid)
   }
 
-  it should "be able to decode a CreatePaymentMethodStateDecoder with Stripe payment fields" in {
-    val state = decode[CreatePaymentMethodState](createStripePaymentMethodJson)
+  it should "be able to decode a monthly contribution with Stripe payment fields" in {
+    val state = decode[CreatePaymentMethodState](createMonthlyStripeJson)
     val result = state.right.get
     result.contribution.amount should be(5)
+    result.contribution.billingPeriod should be(Monthly)
+    result.paymentFields.isLeft should be(true) //Stripe
+    result.paymentFields.left.get.stripeToken should be(stripeToken)
+  }
+
+  it should "be able to decode an annual contribution with Stripe payment fields" in {
+    val state = decode[CreatePaymentMethodState](createAnnualStripeJson)
+    val result = state.right.get
+    result.contribution.amount should be(60)
+    result.contribution.billingPeriod should be(Annual)
     result.paymentFields.isLeft should be(true) //Stripe
     result.paymentFields.left.get.stripeToken should be(stripeToken)
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -32,7 +32,7 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
   it should "be able to decode an annual contribution with Stripe payment fields" in {
     val state = decode[CreatePaymentMethodState](createAnnualStripeJson)
     val result = state.right.get
-    result.contribution.amount should be(60)
+    result.contribution.amount should be(150)
     result.contribution.billingPeriod should be(Annual)
     result.paymentFields.isLeft should be(true) //Stripe
     result.paymentFields.left.get.stripeToken should be(stripeToken)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -4,8 +4,12 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
+import com.gu.support.workers.Conversions.FromOutputStream
 import com.gu.support.workers.Fixtures.{failureJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Encoding
+import com.gu.support.workers.encoding.StateCodecs.completedStateCodec
+import com.gu.support.workers.model.monthlyContributions.state.CompletedState
 import com.gu.test.tags.annotations.IntegrationTest
 import org.joda.time.DateTime
 
@@ -27,7 +31,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     failureHandler.handleRequest(wrapFixture(failureJson), outStream, context)
 
-    assertUnit(outStream)
+    Encoding.in[CompletedState](outStream.toInputStream).isSuccess should be(true)
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.10-SNAPSHOT"
+  val supportModels = "com.gu" %% "support-models" % "0.10"
   val supportConfig = "com.gu" %% "support-config" % "0.6"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,6 @@
 import sbt._
 
+//noinspection TypeAnnotation
 object Dependencies {
   val circeVersion = "0.7.0"
   val awsVersion = "1.11.131"
@@ -10,7 +11,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.9"
+  val supportModels = "com.gu" %% "support-models" % "0.10-SNAPSHOT"
   val supportConfig = "com.gu" %% "support-config" % "0.6"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"


### PR DESCRIPTION
## Why are you doing this?
To enable us to bill supporters annually as well as monthly.

### NB
* This change depends on [this PR](https://github.com/guardian/support-models/pull/13) in support-models. It is backwardly compatible with the existing version of support-frontend, because any request received which does not specify the billing period will default to Monthly.
* This change requires updates to support-worker private conf 


[**Trello Card**](https://trello.com/c/qF6I86xx/878-uk-annual-contributions)

