### PR TITLE
Increase failure handler memory quota

### DIFF
--- a/cloud-formation/src/view.yaml
+++ b/cloud-formation/src/view.yaml
@@ -12,6 +12,7 @@ lambdas:
   memorySize: 512
 - name: FailureHandler
   description: Failure handler
+  memorySize: 512
 - name: SendThankYouEmail
   description: Send thank-you email
 - name: UpdateMembersDataAPI


### PR DESCRIPTION
## Why are you doing this?

Failure handler seems to need more memory when there is a payment
failure

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
