### PR TITLE
Pass the correct parameters into the Salesforce upsert

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -9,10 +9,11 @@ import com.gu.support.workers.model.monthlyContributions.state.{CreateSalesforce
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactState, CreateZuoraSubscriptionState] with LazyLogging {
 
-  override protected def servicesHandler(state: CreateSalesforceContactState, context: Context, services: Services) = {
+  override protected def servicesHandler(state: CreateSalesforceContactState, context: Context, services: Services): Future[CreateZuoraSubscriptionState] = {
     logger.debug(s"CreateSalesforceContact state: $state")
     services.salesforceService.upsert(UpsertData.create(
       state.user.id,
@@ -21,7 +22,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.lastName,
       state.user.allowMembershipMail,
       state.user.allowThirdPartyMail,
-      state.user.allowThirdPartyMail
+      state.user.allowGURelatedMail
     )).map(response =>
       if (response.Success) {
         CreateZuoraSubscriptionState(state.requestId, state.user, state.contribution, state.paymentMethod, response.ContactRecord)


### PR DESCRIPTION
## Why are you doing this?

@pvighi noticed that we were passing the wrong parameter into the 'allow Guardian mail' field in Salesforce, this PR fixes it.

[**Trello Card**](https://trello.com/c/Rr3cbepP/902-fix-mail-permissions-in-support-workers)

