### PR TITLE
Pass the correct parameters into the Salesforce upsert

### DIFF
--- a/common/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/common/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -19,20 +19,24 @@ object Salesforce {
   object UpsertData {
     implicit val codec: Codec[UpsertData] = deriveCodec
 
+    // scalastyle:off parameter.number
     def create(
       identityId: String,
       email: String,
       firstName: String,
       lastName: String,
+      mailingState: Option[String],
+      mailingCountry: String,
       allowMembershipMail: Boolean,
       allow3rdPartyMail: Boolean,
       allowGuardianRelatedMail: Boolean
     ): UpsertData =
       UpsertData(
         NewContact(
-          identityId, email, firstName, lastName, allowMembershipMail, allow3rdPartyMail, allowGuardianRelatedMail
+          identityId, email, firstName, lastName, mailingState, mailingCountry, allowMembershipMail, allow3rdPartyMail, allowGuardianRelatedMail
         )
       )
+    // scalastyle:on parameter.number
   }
 
   //The odd field names on these class are to match with the Salesforce api and allow us to serialise and deserialise
@@ -44,6 +48,8 @@ object Salesforce {
     Email: String,
     FirstName: String,
     LastName: String,
+    MailingState: Option[String],
+    MailingCountry: String,
     Allow_Membership_Mail__c: Boolean,
     Allow_3rd_Party_Mail__c: Boolean,
     Allow_Guardian_Related_Mail__c: Boolean

--- a/common/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/common/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -5,17 +5,19 @@ object Fixtures {
   val salesforceId = "003g000001UnFItAAN"
   val email = "6cwdm8aler7z9r6nwbc@gu.com"
   val name = "6cWdM8AlER7z9R6nWBc"
+  val dummyValue = "Dummy Value"
   val allowMail = false
   val upsertJson =
     s"""{
       "newContact": {
         "IdentityID__c": "$idId",
-         "Email": "$email",
-         "FirstName": "$name",
-         "LastName": "$name",
-         "Allow_Membership_Mail__c": $allowMail,
-         "Allow_3rd_Party_Mail__c": $allowMail,
-         "Allow_Guardian_Related_Mail__c": $allowMail
+        "Email": "$email",
+        "FirstName": "$name",
+        "LastName": "$name",
+        "MailingCountry": "$dummyValue",
+        "Allow_Membership_Mail__c": $allowMail,
+        "Allow_3rd_Party_Mail__c": $allowMail,
+        "Allow_Guardian_Related_Mail__c": $allowMail
        }
       }"""
   val authJson =

--- a/common/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/common/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -5,7 +5,9 @@ object Fixtures {
   val salesforceId = "003g000001UnFItAAN"
   val email = "6cwdm8aler7z9r6nwbc@gu.com"
   val name = "6cWdM8AlER7z9R6nWBc"
-  val dummyValue = "Dummy Value"
+  val uk = "UK"
+  val us = "US"
+  val state = "CA"
   val allowMail = false
   val upsertJson =
     s"""{
@@ -14,7 +16,21 @@ object Fixtures {
         "Email": "$email",
         "FirstName": "$name",
         "LastName": "$name",
-        "MailingCountry": "$dummyValue",
+        "MailingCountry": "$uk",
+        "Allow_Membership_Mail__c": $allowMail,
+        "Allow_3rd_Party_Mail__c": $allowMail,
+        "Allow_Guardian_Related_Mail__c": $allowMail
+       }
+      }"""
+  val upsertJsonWithState =
+    s"""{
+      "newContact": {
+        "IdentityID__c": "$idId",
+        "Email": "$email",
+        "FirstName": "$name",
+        "LastName": "$name",
+        "MailingState": "$state",
+        "MailingCountry": "$us",
         "Allow_Membership_Mail__c": $allowMail,
         "Allow_3rd_Party_Mail__c": $allowMail,
         "Allow_Guardian_Related_Mail__c": $allowMail

--- a/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -51,7 +51,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "SalesforceService" should "be able to upsert a customer" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val upsertData = UpsertData.create(idId, email, name, name, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
       response.Success should be(true)

--- a/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -51,7 +51,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "SalesforceService" should "be able to upsert a customer" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, uk, allowMail, allowMail, allowMail)
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
       response.Success should be(true)

--- a/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -11,9 +11,14 @@ import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging with CustomCodecs {
-  "UpsertData" should "serialise to correct json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail))
+  "UpsertData" should "serialise to correct UK json" in {
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullKeys = true)) should be(parse(upsertJson).right.get.noSpaces)
+  }
+
+  "UpsertData" should "serialise to correct US json" in {
+    val upsertData = UpsertData(NewContact(idId, email, name, name, Some(state), us, allowMail, allowMail, allowMail))
+    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullKeys = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
   }
 
   "Authentication" should "deserialize correctly" in {

--- a/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -4,6 +4,7 @@ import com.gu.salesforce.Fixtures._
 import com.gu.salesforce.Salesforce.{Authentication, NewContact, UpsertData}
 import com.gu.zuora.encoding.CustomCodecs
 import com.typesafe.scalalogging.LazyLogging
+import io.circe.Printer
 import io.circe.parser._
 import io.circe.syntax._
 import org.joda.time.DateTime
@@ -11,8 +12,8 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging with CustomCodecs {
   "UpsertData" should "serialise to correct json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, allowMail, allowMail, allowMail))
-    upsertData.asJson should be(parse(upsertJson).right.get)
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail))
+    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullKeys = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 
   "Authentication" should "deserialize correctly" in {

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -20,6 +20,8 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.primaryEmailAddress,
       state.user.firstName,
       state.user.lastName,
+      state.user.state,
+      state.user.country.name,
       state.user.allowMembershipMail,
       state.user.allowThirdPartyMail,
       state.user.allowGURelatedMail

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -24,7 +24,7 @@ class SalesforceErrorsSpec extends AsyncFlatSpec with Matchers with LazyLogging 
 
   it should "throw a SalesforceAuthenticationErrorResponse if the authentication fails" in {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
-    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, country, allowMail, allowMail, allowMail)
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     assertThrows[SalesforceAuthenticationErrorResponse] {
@@ -35,10 +35,10 @@ class SalesforceErrorsSpec extends AsyncFlatSpec with Matchers with LazyLogging 
   "SalesforceService" should "throw a SalesforceErrorResponse if authentication has expired" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds)) {
       //Don't add the authentication headers to simulate an expired auth token
-      override def addAuthenticationToRequest(auth: Authentication, req: Request.Builder) =
+      override def addAuthenticationToRequest(auth: Authentication, req: Request.Builder): Request.Builder =
         req.url(s"${auth.instance_url}/$upsertEndpoint") //We still need to set the base url
     }
-    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, country, allowMail, allowMail, allowMail)
 
     recoverToSucceededIf[SalesforceErrorResponse] {
       service.upsert(upsertData).map(response => logger.info(s"Got a response: $response"))

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.errors
 
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
-import com.gu.salesforce.Fixtures.{allowMail, email, idId, name}
+import com.gu.salesforce.Fixtures._
 import com.gu.salesforce.Salesforce.{Authentication, SalesforceAuthenticationErrorResponse, SalesforceErrorResponse, UpsertData}
 import com.gu.salesforce.{AuthService, SalesforceConfig, SalesforceService}
 import com.gu.test.tags.annotations.IntegrationTest
@@ -24,7 +24,7 @@ class SalesforceErrorsSpec extends AsyncFlatSpec with Matchers with LazyLogging 
 
   it should "throw a SalesforceAuthenticationErrorResponse if the authentication fails" in {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
-    val upsertData = UpsertData.create(idId, email, name, name, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     assertThrows[SalesforceAuthenticationErrorResponse] {
@@ -38,7 +38,7 @@ class SalesforceErrorsSpec extends AsyncFlatSpec with Matchers with LazyLogging 
       override def addAuthenticationToRequest(auth: Authentication, req: Request.Builder) =
         req.url(s"${auth.instance_url}/$upsertEndpoint") //We still need to set the base url
     }
-    val upsertData = UpsertData.create(idId, email, name, name, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, dummyValue, allowMail, allowMail, allowMail)
 
     recoverToSucceededIf[SalesforceErrorResponse] {
       service.upsert(upsertData).map(response => logger.info(s"Got a response: $response"))


### PR DESCRIPTION
## Why are you doing this?
To ensure that we are passing the same fields to Salesforce as we are to Zuora, this reduces the chance of data getting lost in syncs between the two systems.

[**Trello Card**](https://trello.com/c/7XRbUJkC/916-add-additional-fields-into-the-data-we-send-to-salesforce)