### PR TITLE
Take encryption settings from the request state, not config

### DIFF
--- a/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
@@ -7,6 +7,7 @@ import cats.syntax.either._
 import com.gu.support.workers.encoding.Encryption._
 import com.gu.support.workers.encoding.Wrapper._
 import com.gu.support.workers.model.ExecutionError
+import com.gu.zuora.encoding.CustomCodecs.{jsonWrapperDecoder, jsonWrapperEncoder}
 
 import scala.util.Try
 
@@ -16,16 +17,16 @@ private[workers] object Encoding {
   import io.circe.parser._
   import io.circe.syntax._
 
-  def in[T](is: InputStream)(implicit decoder: Decoder[T]): Try[(T, Option[ExecutionError])] =
+  def in[T](is: InputStream)(implicit decoder: Decoder[T]): Try[(T, Boolean, Option[ExecutionError])] =
     for {
       wrapper <- unWrap(is)
       state <- Try(Base64.getDecoder.decode(wrapper.state))
-      decrypted <- Try(decrypt(state))
+      decrypted <- Try(decrypt(state, wrapper.encrypted))
       result <- decode[T](decrypted).toTry
-    } yield (result, wrapper.error)
+    } yield (result, wrapper.encrypted, wrapper.error)
 
-  def out[T](value: T, os: OutputStream)(implicit encoder: Encoder[T]): Try[Unit] = {
-    val t = Try(os.write(wrap(value).asJson.noSpaces.getBytes()))
+  def out[T](value: T, encrypted: Boolean, os: OutputStream)(implicit encoder: Encoder[T]): Try[Unit] = {
+    val t = Try(os.write(wrap(value, encrypted).asJson.noSpaces.getBytes()))
     os.close()
     t
   }

--- a/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
+++ b/common/src/main/scala/com/gu/support/workers/encoding/Wrapper.scala
@@ -5,8 +5,8 @@ import java.util.Base64
 
 import cats.syntax.either._
 import com.gu.support.workers.encoding.Encryption.encrypt
-import com.gu.support.workers.encoding.Helpers.deriveCodec
-import com.gu.support.workers.model.{ExecutionError, JsonWrapper}
+import com.gu.support.workers.model.JsonWrapper
+import com.gu.zuora.encoding.CustomCodecs.{jsonWrapperDecoder, jsonWrapperEncoder}
 import io.circe.Encoder
 import io.circe.parser._
 import io.circe.syntax._
@@ -20,19 +20,16 @@ import scala.util.Try
  * This class helps with that
  */
 object Wrapper {
-  implicit val executionErrorCodec: Codec[ExecutionError] = deriveCodec
-  implicit val jsonCodec: Codec[JsonWrapper] = deriveCodec
-
   def unWrap(is: InputStream): Try[JsonWrapper] = {
     val t = Try(Source.fromInputStream(is).mkString).flatMap(decode[JsonWrapper](_).toTry)
     is.close()
     t
   }
 
-  def wrap[T](value: T)(implicit encoder: Encoder[T]): JsonWrapper =
-    wrapString(value.asJson.noSpaces)
+  def wrap[T](value: T, encrypted: Boolean)(implicit encoder: Encoder[T]): JsonWrapper =
+    wrapString(value.asJson.noSpaces, encrypted)
 
-  def wrapString(string: String): JsonWrapper = JsonWrapper(encodeToBase64String(encrypt(string)), None)
+  def wrapString(string: String, encrypted: Boolean): JsonWrapper = JsonWrapper(encodeToBase64String(encrypt(string, encrypted)), None, encrypted)
 
   def encodeToBase64String(value: Array[Byte]): String = new String(Base64.getEncoder.encode(value))
 }

--- a/common/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
+++ b/common/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
@@ -4,11 +4,11 @@ import java.io.{InputStream, OutputStream}
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import com.gu.support.workers.exceptions.ErrorHandler
+import com.gu.support.workers.model.ExecutionError
 import io.circe.{Decoder, Encoder}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import com.gu.support.workers.model.ExecutionError
 
 abstract class Handler[T, R](implicit decoder: Decoder[T], encoder: Encoder[R]) extends RequestStreamHandler {
   import com.gu.support.workers.encoding.Encoding._
@@ -17,7 +17,7 @@ abstract class Handler[T, R](implicit decoder: Decoder[T], encoder: Encoder[R]) 
 
   def handleRequest(is: InputStream, os: OutputStream, context: Context): Unit =
     try {
-      in(is).flatMap({ case (i, error) => out(handler(i, error, context), os) }).get
+      in(is).flatMap({ case (i, encrypted, error) => out(handler(i, error, context), encrypted, os) }).get
     } catch ErrorHandler.handleException
 }
 

--- a/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
+++ b/common/src/main/scala/com/gu/zuora/ZuoraConfig.scala
@@ -11,8 +11,9 @@ case class ZuoraConfig(
   username: String,
   password: String,
   monthlyContribution: ZuoraContributionConfig,
-  annualContribution: ZuoraContributionConfig)
-  extends TouchpointConfig {
+  annualContribution: ZuoraContributionConfig
+)
+    extends TouchpointConfig {
   def configForBillingPeriod(billingPeriod: BillingPeriod): ZuoraContributionConfig =
     billingPeriod match {
       case Annual => annualContribution

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -71,7 +71,7 @@ trait ModelsCodecs {
   implicit val executionErrorCodec: Codec[ExecutionError] = deriveCodec
   implicit val jsonWrapperDecoder: Decoder[JsonWrapper] = Decoder
     .forProduct3("state", "error","encrypted")(JsonWrapper.apply)
-    .or(Decoder.forProduct2("state", "error")((s: String, e: Option[ExecutionError]) => JsonWrapper(s, e)))
+    .or(Decoder.forProduct2("state", "error")((s: String, e: Option[ExecutionError]) => JsonWrapper(s, e, encrypted = false)))
   implicit val jsonWrapperEncoder: Encoder[JsonWrapper] = deriveEncoder
 
 }

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -70,7 +70,7 @@ trait ModelsCodecs {
 
   implicit val executionErrorCodec: Codec[ExecutionError] = deriveCodec
   implicit val jsonWrapperDecoder: Decoder[JsonWrapper] = Decoder
-    .forProduct3("state", "error","encrypted")(JsonWrapper.apply)
+    .forProduct3("state", "error", "encrypted")(JsonWrapper.apply)
     .or(Decoder.forProduct2("state", "error")((s: String, e: Option[ExecutionError]) => JsonWrapper(s, e, encrypted = false)))
   implicit val jsonWrapperEncoder: Encoder[JsonWrapper] = deriveEncoder
 

--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -15,7 +15,6 @@ import org.joda.time.{DateTime, LocalDate}
 
 import scala.util.Try
 
-
 object CustomCodecs extends CustomCodecs with InternationalisationCodecs with ModelsCodecs with HelperCodecs
 
 trait InternationalisationCodecs {
@@ -68,6 +67,13 @@ trait ModelsCodecs {
     .forProduct3("amount", "currency", "billingPeriod")(Contribution.apply)
     .or(Decoder.forProduct2("amount", "currency")((a: BigDecimal, c: Currency) => Contribution(a, c)))
   implicit val encodeContribution: Encoder[Contribution] = deriveEncoder
+
+  implicit val executionErrorCodec: Codec[ExecutionError] = deriveCodec
+  implicit val jsonWrapperDecoder: Decoder[JsonWrapper] = Decoder
+    .forProduct3("state", "error","encrypted")(JsonWrapper.apply)
+    .or(Decoder.forProduct2("state", "error")((s: String, e: Option[ExecutionError]) => JsonWrapper(s, e)))
+  implicit val jsonWrapperEncoder: Encoder[JsonWrapper] = deriveEncoder
+
 }
 
 trait HelperCodecs {

--- a/common/src/test/scala/com/gu/encryption/EncryptionSpec.scala
+++ b/common/src/test/scala/com/gu/encryption/EncryptionSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.encryption
 
+import com.gu.config.Configuration
 import com.gu.support.workers.encoding.AwsEncryptionProvider
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
@@ -12,7 +13,7 @@ class EncryptionSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
     val text = "Some test text"
 
-    val encryption = new AwsEncryptionProvider()
+    val encryption = new AwsEncryptionProvider(Configuration.awsConfig)
 
     val encrypted = encryption.encrypt(text)
 

--- a/common/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/common/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -185,8 +185,8 @@ object Fixtures {
         $subscribeResponseAccount
       ]
     """
- val subscribeResponseAnnual =
-   """
+  val subscribeResponseAnnual =
+    """
      [
         {
           "AccountNumber": "A00016540",

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Conversions.scala
@@ -23,9 +23,9 @@ object Conversions {
   }
 
   implicit class FromOutputStream(val self: ByteArrayOutputStream) {
-    def toClass[T]()(implicit decoder: Decoder[T]): T = {
+    def toClass[T](encrypted: Boolean)(implicit decoder: Decoder[T]): T = {
       val is = self.toInputStream
-      val str = Encryption.decrypt(Streamable.bytes(is))
+      val str = Encryption.decrypt(Streamable.bytes(is), encrypted)
       val t = Try(str).flatMap(decode[T](_).toTry)
       is.close()
       t.get

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -3,10 +3,10 @@ package com.gu.support.workers
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
 import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrapFixture}
-import com.gu.support.workers.encoding.Wrapper.jsonCodec
 import com.gu.support.workers.lambdas._
 import com.gu.support.workers.model.JsonWrapper
 import com.gu.test.tags.annotations.IntegrationTest
+import com.gu.zuora.encoding.CustomCodecs.{jsonWrapperDecoder, jsonWrapperEncoder}
 import io.circe.parser._
 
 import scala.io.Source

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -24,7 +24,7 @@ class EndToEndSpec extends LambdaSpec {
 
     val decoded = decode[List[JsonWrapper]](output.toString("utf-8"))
     decoded.isRight should be(true)
-    decoded.right.get.size should be (2)
+    decoded.right.get.size should be(2)
   }
 
   implicit class InputStreamChaining(val stream: InputStream) {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -5,12 +5,19 @@ import java.io.ByteArrayInputStream
 import com.gu.salesforce.Fixtures.idId
 import com.gu.support.workers.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Wrapper
-import com.gu.support.workers.encoding.Wrapper.jsonCodec
+import com.gu.zuora.encoding.CustomCodecs.jsonWrapperEncoder
 import io.circe.syntax._
 
 //noinspection TypeAnnotation
 object Fixtures {
-  def wrapFixture(string: String): ByteArrayInputStream = Wrapper.wrapString(string).asJson.noSpaces.asInputStream
+  val useEncryption = false
+
+  def wrapFixture(string: String): ByteArrayInputStream = Wrapper.wrapString(string, useEncryption).asJson.noSpaces.asInputStream
+
+  val oldJsonWrapper =
+    """
+      {"state":"CiAgICAgIHsKICAgICAgICAiYW1vdW50IjogNSwKICAgICAgICAiY3VycmVuY3kiOiAiR0JQIgogICAgICB9CiAgICA=","error":null}
+    """.asInputStream
 
   val userJson =
     s"""

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,16 +1,22 @@
 package com.gu.support.workers
 
-import com.gu.support.workers.Fixtures.{monthlyContributionJson, wrapFixture}
+import com.gu.support.workers.Fixtures.{monthlyContributionJson, oldJsonWrapper, wrapFixture}
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.zuora.encoding.CustomCodecs._
+import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
 
-class WrapperSpec extends FlatSpec with Matchers {
-  "Wrapper" should "be able to round trip some json" in {
+class WrapperSpec extends FlatSpec with Matchers with LazyLogging {
+  "JsonWrapper" should "be able to round trip some json" in {
     val wrapped = wrapFixture(monthlyContributionJson)
 
     val contribution = Encoding.in[Contribution](wrapped)
+    contribution.isSuccess should be(true)
+  }
+
+  it should "be able to handle old versions of the json with a missing encrypted parameter" in {
+    val contribution = Encoding.in[Contribution](oldJsonWrapper)
     contribution.isSuccess should be(true)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -72,7 +72,7 @@ class CreatePaymentMethodSpec extends LambdaSpec {
 
       createPaymentMethod.handleRequest(inStream, outStream, mock[Context])
 
-      val p = outStream.toClass[PaymentMethod]()
+      val p = outStream.toClass[PaymentMethod](encrypted = false)
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.11-SNAPSHOT"
+  val supportModels = "com.gu" %% "support-models" % "0.14"
   val supportConfig = "com.gu" %% "support-config" % "0.6"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
-  val supportModels = "com.gu" %% "support-models" % "0.10"
+  val supportModels = "com.gu" %% "support-models" % "0.11-SNAPSHOT"
   val supportConfig = "com.gu" %% "support-config" % "0.6"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"


### PR DESCRIPTION
## Why are you doing this?
To make it easier to switch encryption on and off without a risk of support-frontend and support-workers getting out of sync, this PR moves the setting which determines whether a request is encrypted or not into the request state rather than the config setting.

This means that support-frontend is now the only place where we need to update the encryption setting and support-workers will handle whatever it is sent. This would also allow us to send a mix of encrypted and unencrypted requests if for instance we wanted to keep test user requests unencrypted

Depends on PR https://github.com/guardian/support-models/pull/17

[**Trello Card**](https://trello.com/c/PxnJi97v/948-switch-on-encryption-in-the-support-stack)


