### PR TITLE
Correct the email payload which we send to ExactTarget

### DIFF
--- a/common/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -24,13 +24,15 @@ case class EmailFields(
        |    "Address": "$email",
        |    "SubscriberKey": "$email",
        |    "ContactAttributes": {
-       |      "EmailAddress": "$email",
-       |      "created": "$created",
-       |      "amount": $amount,
-       |      "currency": "$currency",
-       |      "edition": "$edition",
-       |      "name": "$name",
-       |      "product": "$product"
+       |      "SubscriberAttributes": {
+       |        "EmailAddress": "$email",
+       |        "created": "$created",
+       |        "amount": $amount,
+       |        "currency": "$currency",
+       |        "edition": "$edition",
+       |        "name": "$name",
+       |        "product": "$product"
+       |      }
        |    }
        |  },
        |  "DataExtensionName": "$dataExtensionName"


### PR DESCRIPTION
## Why are you doing this?

Whilst investigating how to customise the thank you email for US contributors I noticed that the data which we pass through to ExactTarget was not being recorded correctly. 

The reason for this was that the json structure we were sending was incorrect, this PR fixes it.

[**Trello Card**](https://trello.com/c/KnSMJIka/761-update-thank-you-email-to-allow-us-to-send-different-copy-to-us-and-uk-and-row-contributors)

