### PR TITLE
adds cloudwatch metrics for each lambda function

### DIFF
--- a/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
+++ b/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
@@ -18,13 +18,15 @@ class RecurringContributionsMetrics(
 
   def putContributionSignUpStartProcess(): Future[Unit] = put(s"monthly-contributor-sign-up-start")
 
-  def putCreatePaymentMethod(): Future[Unit] = put(s"monthly-contributor-payment-method-created")
+  def putPaymentMethodCreated(): Future[Unit] = put(s"monthly-contributor-payment-method-created")
 
   def putZuoraAccountCreated(): Future[Unit] = put(s"monthly-contributor-zuora-account-created")
 
-  def putSalesforceAccountCreated(): Future[Unit] = put(s"monthly-contributor-salesforce-account-created")
+  def putSalesforceContactCreated(): Future[Unit] = put(s"monthly-contributor-salesforce-contact-created")
 
   def putThankYouEmailSent(): Future[Unit] = put(s"monthly-contributor-thank-you-email-sent")
+
+  def putContributionCompleted(): Future[Unit] = put(s"monthly-contributor-contribution-completed")
 
   private def put(metricName: String): Future[Unit] = put(metricName, 1).map(_ => ())
 

--- a/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
+++ b/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
@@ -18,7 +18,26 @@ class RecurringContributionsMetrics(
 
   def putContributionSignUpStartProcess(): Future[Unit] = put(s"monthly-contributor-sign-up-start")
 
+  def putCreatePaymentMethod(): Future[Unit] = put(s"monthly-contributor-payment-method-created")
+
   def putZuoraAccountCreated(): Future[Unit] = put(s"monthly-contributor-zuora-account-created")
+
+  def putSalesforceAccountCreated(): Future[Unit] = put(s"monthly-contributor-salesforce-account-created")
+
+  def putThankYouEmailSent(): Future[Unit] = put(s"monthly-contributor-thank-you-email-sent")
+
+  private def put(metricName: String): Future[Unit] = put(metricName, 1).map(_ => ())
+
+}
+
+class FailureMetrics(
+  period: String
+) extends CloudWatch(
+  productName("RecurringContributor"),
+  subscriptionPeriod(period)
+) {
+
+  def putFailureHandlerTriggered(): Future[Unit] = put(s"monthly-contributor-failure-handler-triggered")
 
   private def put(metricName: String): Future[Unit] = put(metricName, 1).map(_ => ())
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
@@ -33,6 +33,5 @@ object StateDecoder extends App with LazyLogging {
     print(encoder.decrypt(state))
   }
 
-
   def print(output: String): Unit = println(s"\n\n$output\n\n") // scalastyle:ignore
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
@@ -33,5 +33,6 @@ object StateDecoder extends App with LazyLogging {
     print(encoder.decrypt(state))
   }
 
+
   def print(output: String): Unit = println(s"\n\n$output\n\n") // scalastyle:ignore
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
@@ -1,17 +1,21 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.ExecutionError
 import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, SendThankYouEmailState}
 import com.gu.support.workers.model.monthlyContributions.Status
 import com.typesafe.scalalogging.LazyLogging
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class ContributionCompleted
     extends Handler[SendThankYouEmailState, CompletedState]
     with LazyLogging {
 
   override protected def handler(state: SendThankYouEmailState, error: Option[ExecutionError], context: Context): CompletedState = {
+
     val fields = List(
       "contribution_amount" -> state.contribution.amount.toString,
       "contribution_currency" -> state.contribution.currency.iso.toString,
@@ -20,6 +24,7 @@ class ContributionCompleted
     )
 
     logger.info(fields.map({ case (k, v) => s"$k: $v" }).mkString("SUCCESS ", " ", ""))
+    putContributionCompleted(state.paymentMethod.`type`)
 
     CompletedState(
       requestId = state.requestId,
@@ -29,4 +34,9 @@ class ContributionCompleted
       message = None
     )
   }
+
+  def putContributionCompleted(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+      .putContributionCompleted().recover({ case _ => () })
+
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -28,7 +28,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.allowGURelatedMail
     )).map(response =>
       if (response.Success) {
-        putMetric(state.paymentMethod.`type`)
+        putSalesForceContactCreated(state.paymentMethod.`type`)
         getCreateZuoraSubscriptionState(state, response)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
@@ -47,14 +47,8 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.acquisitionData
     )
 
-  private def putMetric(paymentType: String) =
-    if (paymentType == "PayPal")
-      putCloudWatchMetrics("paypal")
-    else
-      putCloudWatchMetrics("stripe")
-
-  def putCloudWatchMetrics(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod, "monthly")
-      .putSalesforceAccountCreated().recover({ case _ => () })
+  def putSalesForceContactCreated(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+      .putSalesforceContactCreated().recover({ case _ => () })
 
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.salesforce.Salesforce.{SalesforceContactResponse, UpsertData}
 import com.gu.services.Services
 import com.gu.support.workers.encoding.StateCodecs._
@@ -27,6 +28,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.allowGURelatedMail
     )).map(response =>
       if (response.Success) {
+        putMetric(state.paymentMethod.`type`)
         getCreateZuoraSubscriptionState(state, response)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
@@ -44,4 +46,15 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       response.ContactRecord,
       state.acquisitionData
     )
+
+  private def putMetric(paymentType: String) =
+    if (paymentType == "PayPal")
+      putCloudWatchMetrics("paypal")
+    else
+      putCloudWatchMetrics("stripe")
+
+  def putCloudWatchMetrics(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod, "monthly")
+      .putSalesforceAccountCreated().recover({ case _ => () })
+
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -28,7 +28,7 @@ class FailureHandler(emailService: EmailService)
     logger.info(
       s"FAILED contribution_amount: ${state.contribution.amount} contribution_currency: ${state.contribution.currency.iso} test_user: ${state.user.isTestUser}"
     )
-    putCloudWatchMetric()
+    putFailureHandlerTriggered()
     emailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -65,7 +65,7 @@ class FailureHandler(emailService: EmailService)
     }
   }
 
-  def putCloudWatchMetric(): Future[Unit] = {
+  def putFailureHandlerTriggered(): Future[Unit] = {
     new FailureMetrics("monthly")
       .putFailureHandlerTriggered().recover({ case _ => () })
   }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers.lambdas
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
+import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.ExecutionError
 import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
@@ -23,6 +24,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
   }
 
   def sendEmail(state: SendThankYouEmailState): Future[Unit] = {
+    putMetric(state.paymentMethod.`type`)
     thankYouEmailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -33,4 +35,14 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
       product = "monthly-contribution"
     )).map(_ => Unit)
   }
+
+  private def putMetric(paymentType: String) =
+    if (paymentType == "PayPal")
+      putCloudWatchMetrics("paypal")
+    else
+      putCloudWatchMetrics("stripe")
+
+  def putCloudWatchMetrics(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod, "monthly")
+      .putThankYouEmailSent().recover({ case _ => () })
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -24,7 +24,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
   }
 
   def sendEmail(state: SendThankYouEmailState): Future[Unit] = {
-    putMetric(state.paymentMethod.`type`)
+    putThankYouEmailSent(state.paymentMethod.`type`)
     thankYouEmailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -36,13 +36,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
     )).map(_ => Unit)
   }
 
-  private def putMetric(paymentType: String) =
-    if (paymentType == "PayPal")
-      putCloudWatchMetrics("paypal")
-    else
-      putCloudWatchMetrics("stripe")
-
-  def putCloudWatchMetrics(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod, "monthly")
+  def putThankYouEmailSent(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
       .putThankYouEmailSent().recover({ case _ => () })
 }


### PR DESCRIPTION
There are currently a small number of cloudwatch metrics sent by this application under the "support-worker" namespace. This change adds some more.
The reason for these new metrics is so that I create some composite metrics in a tool called "librato" that will calculate the ratio of successful completions of monthly payments to number of payments attempted and trigger an alert if this falls below a particular rate.

Why here when there are lambda metrics and state-machine metrics in AWS already?
1) It is not currently possible to import metrics under the "state" namespace into Librato. They are just not recognised.
2) Should this change, there is still a problem with the metrics in the "state" namespace. Their metric name includes a versioning id. This changes each time a new version is deployed, so I'd have to be continually updating the "Lambda" namespace are divded by type of metric. The actual function they represent is set as a tag. Unfortunately, for some reason not all of these tags are being pulled through for the librato metrics (I suspect we have exceeded the maximum number of tags librato can handle for a single metric with these metrics).

This change is part of the following [trello card](https://trello.com/c/tmz6kxm2/919-make-sure-client-side-logging-and-metrics-up-to-scratch).