### PR TITLE
set stripe payment metrics to have a better label

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
@@ -24,7 +24,7 @@ class ContributionCompleted
     )
 
     logger.info(fields.map({ case (k, v) => s"$k: $v" }).mkString("SUCCESS ", " ", ""))
-    putContributionCompleted(state.paymentMethod.`type`)
+    putContributionCompleted(state.paymentMethod.toString)
 
     CompletedState(
       requestId = state.requestId,
@@ -35,8 +35,15 @@ class ContributionCompleted
     )
   }
 
-  def putContributionCompleted(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+  def putContributionCompleted(paymentMethod: String): Future[Unit] = {
+    val paymentMethodLabel = {
+      if(paymentMethod.contains("CreditCardReferenceTransaction"))
+        "stripe"
+      else
+        "paypal"
+    }
+    new RecurringContributionsMetrics(paymentMethodLabel, "monthly")
       .putContributionCompleted().recover({ case _ => () })
+  }
 
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -47,8 +47,15 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.acquisitionData
     )
 
-  def putSalesForceContactCreated(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+  def putSalesForceContactCreated(paymentMethod: String): Future[Unit] = {
+    val paymentMethodLabel = {
+      if(paymentMethod.contains("CreditCardReferenceTransaction"))
+        "stripe"
+      else
+        "paypal"
+    }
+    new RecurringContributionsMetrics(paymentMethodLabel, "monthly")
       .putSalesforceContactCreated().recover({ case _ => () })
+  }
 
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -96,7 +96,14 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     ))
   }
 
-  def putZuoraAccountCreated(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+  def putZuoraAccountCreated(paymentMethod: String): Future[Unit] = {
+    val paymentMethodLabel = {
+      if(paymentMethod.contains("CreditCardReferenceTransaction"))
+        "stripe"
+      else
+        "paypal"
+    }
+    new RecurringContributionsMetrics(paymentMethodLabel.toLowerCase, "monthly")
       .putZuoraAccountCreated().recover({ case _ => () })
+  }
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -36,7 +36,14 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
     )).map(_ => Unit)
   }
 
-  def putThankYouEmailSent(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+  def putThankYouEmailSent(paymentMethod: String): Future[Unit] = {
+    val paymentMethodLabel = {
+      if(paymentMethod.contains("CreditCardReferenceTransaction"))
+        "stripe"
+      else
+        "paypal"
+    }
+    new RecurringContributionsMetrics(paymentMethodLabel.toLowerCase, "monthly")
       .putThankYouEmailSent().recover({ case _ => () })
+  }
 }


### PR DESCRIPTION
Metrics tracking payments were added in https://github.com/guardian/support-workers/pull/68
These metrics are pulling through ok, however the payment method label for stripe payments is coming through as "CreditCardReferenceTransaction", not "stripe".

This change fixes that problem and will make the metrics easier to follow.
