### PR TITLE
Revert "adds cloudwatch metrics for each lambda function"

### DIFF
--- a/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
+++ b/common/src/main/scala/com/gu/monitoring/products/RecurringContributionsMetrics.scala
@@ -18,28 +18,7 @@ class RecurringContributionsMetrics(
 
   def putContributionSignUpStartProcess(): Future[Unit] = put(s"monthly-contributor-sign-up-start")
 
-  def putPaymentMethodCreated(): Future[Unit] = put(s"monthly-contributor-payment-method-created")
-
   def putZuoraAccountCreated(): Future[Unit] = put(s"monthly-contributor-zuora-account-created")
-
-  def putSalesforceContactCreated(): Future[Unit] = put(s"monthly-contributor-salesforce-contact-created")
-
-  def putThankYouEmailSent(): Future[Unit] = put(s"monthly-contributor-thank-you-email-sent")
-
-  def putContributionCompleted(): Future[Unit] = put(s"monthly-contributor-contribution-completed")
-
-  private def put(metricName: String): Future[Unit] = put(metricName, 1).map(_ => ())
-
-}
-
-class FailureMetrics(
-  period: String
-) extends CloudWatch(
-  productName("RecurringContributor"),
-  subscriptionPeriod(period)
-) {
-
-  def putFailureHandlerTriggered(): Future[Unit] = put(s"monthly-contributor-failure-handler-triggered")
 
   private def put(metricName: String): Future[Unit] = put(metricName, 1).map(_ => ())
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
@@ -1,21 +1,17 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.ExecutionError
 import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, SendThankYouEmailState}
 import com.gu.support.workers.model.monthlyContributions.Status
 import com.typesafe.scalalogging.LazyLogging
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 class ContributionCompleted
     extends Handler[SendThankYouEmailState, CompletedState]
     with LazyLogging {
 
   override protected def handler(state: SendThankYouEmailState, error: Option[ExecutionError], context: Context): CompletedState = {
-
     val fields = List(
       "contribution_amount" -> state.contribution.amount.toString,
       "contribution_currency" -> state.contribution.currency.iso.toString,
@@ -24,7 +20,6 @@ class ContributionCompleted
     )
 
     logger.info(fields.map({ case (k, v) => s"$k: $v" }).mkString("SUCCESS ", " ", ""))
-    putContributionCompleted(state.paymentMethod.`type`)
 
     CompletedState(
       requestId = state.requestId,
@@ -34,9 +29,4 @@ class ContributionCompleted
       message = None
     )
   }
-
-  def putContributionCompleted(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
-      .putContributionCompleted().recover({ case _ => () })
-
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.salesforce.Salesforce.{SalesforceContactResponse, UpsertData}
 import com.gu.services.Services
 import com.gu.support.workers.encoding.StateCodecs._
@@ -28,7 +27,6 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.allowGURelatedMail
     )).map(response =>
       if (response.Success) {
-        putSalesForceContactCreated(state.paymentMethod.`type`)
         getCreateZuoraSubscriptionState(state, response)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
@@ -46,9 +44,4 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       response.ContactRecord,
       state.acquisitionData
     )
-
-  def putSalesForceContactCreated(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
-      .putSalesforceContactCreated().recover({ case _ => () })
-
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -35,7 +35,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   def subscribe(state: CreateZuoraSubscriptionState, services: Services): Future[SendThankYouEmailState] =
     for {
       response <- services.zuoraService.subscribe(buildSubscribeRequest(state))
-      _ <- putZuoraAccountCreated(state.paymentMethod.`type`)
+      _ <- putMetric(state.paymentMethod.`type`)
     } yield getEmailState(state, response.head.accountNumber)
 
   private def getEmailState(state: CreateZuoraSubscriptionState, accountNumber: String) =
@@ -96,7 +96,13 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     ))
   }
 
-  def putZuoraAccountCreated(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
+  private def putMetric(paymentType: String) =
+    if (paymentType == "PayPal")
+      putCloudWatchMetrics("paypal")
+    else
+      putCloudWatchMetrics("stripe")
+
+  def putCloudWatchMetrics(paymentMethod: String): Future[Unit] =
+    new RecurringContributionsMetrics(paymentMethod, "monthly")
       .putZuoraAccountCreated().recover({ case _ => () })
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
 import com.gu.helpers.FutureExtensions._
-import com.gu.monitoring.products.{FailureMetrics, RecurringContributionsMetrics}
 import com.gu.support.workers.encoding.ErrorJson
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.ExecutionError
@@ -28,7 +27,6 @@ class FailureHandler(emailService: EmailService)
     logger.info(
       s"FAILED contribution_amount: ${state.contribution.amount} contribution_currency: ${state.contribution.currency.iso} test_user: ${state.user.isTestUser}"
     )
-    putFailureHandlerTriggered()
     emailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -64,10 +62,4 @@ class FailureHandler(emailService: EmailService)
         "There was an error processing your payment. Please\u00a0try\u00a0again."
     }
   }
-
-  def putFailureHandlerTriggered(): Future[Unit] = {
-    new FailureMetrics("monthly")
-      .putFailureHandlerTriggered().recover({ case _ => () })
-  }
-
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -3,7 +3,6 @@ package com.gu.support.workers.lambdas
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
-import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.ExecutionError
 import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
@@ -24,7 +23,6 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
   }
 
   def sendEmail(state: SendThankYouEmailState): Future[Unit] = {
-    putThankYouEmailSent(state.paymentMethod.`type`)
     thankYouEmailService.send(EmailFields(
       email = state.user.primaryEmailAddress,
       created = DateTime.now(),
@@ -35,8 +33,4 @@ class SendThankYouEmail(thankYouEmailService: EmailService)
       product = "monthly-contribution"
     )).map(_ => Unit)
   }
-
-  def putThankYouEmailSent(paymentMethod: String): Future[Unit] =
-    new RecurringContributionsMetrics(paymentMethod.toLowerCase, "monthly")
-      .putThankYouEmailSent().recover({ case _ => () })
 }


### PR DESCRIPTION
Reverts guardian/support-workers#68

This is reverting a change that added extra cloudwatch metrics to our Lambda functions.
This was so that we could take advantage of the composite metrics and alerting in Librato tocreate alerts on the rates of success vs attempts on out Lambda functions.

The new metrics were necessary because the full complement of tags for the standard AWS Lambda metrics were not being pulled through by Librato - as a result they were missing critical data.

Librato has just informed me that they have managed to fix this bug and I have tested and confirmed that all tags for the standard AWS Lambda metrics are now pulling through.
As a result the duplicate metrics are no longer needed and can be removed (no sense paying for something we already have).