### PR TITLE
Use latest riff-raff plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.5")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 


### PR DESCRIPTION
## Why are you doing this?

1. To keep things up to date 
2. Because this version of the plugin seems to ensure that tests are passing before uploading to S3, and we had a problem before where riff-raff would deploy a build, even if the tests on master were red - so this gives us some additional safety.

## Changes

* Update plugin

I can deploy this branch to CODE, and I'm assuming that's the only testing required for this.