### PR TITLE
Add alarms for no executions and failed executions

### DIFF
--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -124,42 +124,42 @@ Resources:
 
   NoStateMachineExecutionsAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateCodeResources
+    Condition: CreateProdResources
     Properties:
       InsufficientDataActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       OKActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub No Recent State Machine Execution Attempts in ${Stage} (Monthly Contributions Sign-Ups)
       AlarmDescription: The Monthly Contribtions state machine has not been triggered for 3 hours - has something broken?
       MetricName: ExecutionsStarted
       Namespace: AWS/States
       Dimensions:
         - Name: StateMachineArn
-          Value: !Ref MonthlyContributionsCODE
+          Value: !Ref MonthlyContributionsPROD
       ComparisonOperator: LessThanThreshold
       Threshold: 1
       Period: 7200
       EvaluationPeriods: 1
       Statistic: Sum
-    DependsOn: MonthlyContributionsCODE
+    DependsOn: MonthlyContributionsPROD
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: CreateCodeResources
+    Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub State Machine Failure in ${Stage} (Monthly Contributions Sign-Ups)
       AlarmDescription: The Monthly Contribtions state machine failed during execution - please investigate.
       MetricName: ExecutionsFailed
       Namespace: AWS/States
       Dimensions:
         - Name: StateMachineArn
-          Value: !Ref MonthlyContributionsCODE
+          Value: !Ref MonthlyContributionsPROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-    DependsOn: MonthlyContributionsCODE
+    DependsOn: MonthlyContributionsPROD

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -159,7 +159,7 @@ Resources:
           Value: !Ref MonthlyContributionsCODE
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
-      Period: 300
+      Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
     DependsOn: MonthlyContributionsCODE

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -130,7 +130,7 @@ Resources:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
       OKActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
-      AlarmName: No Recent State Machine Execution Attempts (Monthly Contributions Sign-Ups)
+      AlarmName: !Sub No Recent State Machine Execution Attempts in ${Stage} (Monthly Contributions Sign-Ups)
       AlarmDescription: The Monthly Contribtions state machine has not been triggered for 3 hours - has something broken?
       MetricName: ExecutionsStarted
       Namespace: AWS/States
@@ -150,7 +150,7 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
-      AlarmName: State Machine Failure (Monthly Contributions Sign-Ups)
+      AlarmName: !Sub State Machine Failure in ${Stage} (Monthly Contributions Sign-Ups)
       AlarmDescription: The Monthly Contribtions state machine failed during execution - please investigate.
       MetricName: ExecutionsFailed
       Namespace: AWS/States

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -131,7 +131,7 @@ Resources:
       OKActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub No Recent State Machine Execution Attempts in ${Stage} (Monthly Contributions Sign-Ups)
-      AlarmDescription: The Monthly Contribtions state machine has not been triggered for an extended period - has something broken?
+      AlarmDescription: The Monthly Contributions state machine has not been triggered for an extended period - has something broken?
       MetricName: ExecutionsStarted
       Namespace: AWS/States
       Dimensions:
@@ -151,7 +151,7 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub State Machine Failure in ${Stage} (Monthly Contributions Sign-Ups)
-      AlarmDescription: The Monthly Contribtions state machine failed during execution - please investigate.
+      AlarmDescription: The Monthly Contributions state machine failed during execution - please investigate.
       MetricName: ExecutionsFailed
       Namespace: AWS/States
       Dimensions:

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -126,7 +126,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateCodeResources
     Properties:
-      AlarmActions:
+      InsufficientDataActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
       OKActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
@@ -139,7 +139,7 @@ Resources:
           Value: !Ref MonthlyContributionsCODE
       ComparisonOperator: LessThanThreshold
       Threshold: 1
-      Period: 10800
+      Period: 7200
       EvaluationPeriods: 1
       Statistic: Sum
     DependsOn: MonthlyContributionsCODE

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -121,3 +121,45 @@ Resources:
 
           - {}
       RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
+
+  NoStateMachineExecutionsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateCodeResources
+    Properties:
+      AlarmActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      OKActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      AlarmName: No Recent State Machine Execution Attempts (Monthly Contributions Sign-Ups)
+      AlarmDescription: The Monthly Contribtions state machine has not been triggered for 3 hours - has something broken?
+      MetricName: ExecutionsStarted
+      Namespace: AWS/States
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Ref MonthlyContributionsCODE
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1
+      Period: 10800
+      EvaluationPeriods: 1
+      Statistic: Sum
+    DependsOn: MonthlyContributionsCODE
+
+  ExecutionFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateCodeResources
+    Properties:
+      AlarmActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:jacob-testing
+      AlarmName: State Machine Failure (Monthly Contributions Sign-Ups)
+      AlarmDescription: The Monthly Contribtions state machine failed during execution - please investigate.
+      MetricName: ExecutionsFailed
+      Namespace: AWS/States
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Ref MonthlyContributionsCODE
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 300
+      EvaluationPeriods: 1
+      Statistic: Sum
+    DependsOn: MonthlyContributionsCODE

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -131,7 +131,7 @@ Resources:
       OKActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub No Recent State Machine Execution Attempts in ${Stage} (Monthly Contributions Sign-Ups)
-      AlarmDescription: The Monthly Contribtions state machine has not been triggered for 3 hours - has something broken?
+      AlarmDescription: The Monthly Contribtions state machine has not been triggered for an extended period - has something broken?
       MetricName: ExecutionsStarted
       Namespace: AWS/States
       Dimensions:


### PR DESCRIPTION
## Why are you doing this?

This PR adds two new alarms, so that we know if things are broken in production:

**1. NoStateMachineExecutionsAlarm**
Intended to catch cases where the interaction between support-frontend and support-workers is fundamentally broken.

**2. ExecutionFailureAlarm** 
If the Fail State added in https://github.com/guardian/support-workers/pull/77 is triggered, we should be informed so that we can fix the bug (or add more genuine/valid reasons for failure to the handler).
If we break any of the individual lambdas, this should serve as a catch all for that too.

[**Trello Card**](https://trello.com/c/cnYz9x3R/1115-add-basic-production-monitoring-to-support-projects)

## Changes

* Add new alarms to Cloudformation

cc @michaelwmcnamara 