### PR TITLE
Handle external errors which could occur during State Machine executions

### DIFF
--- a/cloud-formation/src/templates/retries.yaml
+++ b/cloud-formation/src/templates/retries.yaml
@@ -9,3 +9,8 @@ Retry:
   IntervalSeconds: 1
   MaxAttempts: 999999 #If we don't provide a value here it defaults to 3
   BackoffRate: 2
+- ErrorEquals:
+  - States.ALL # Wildcard to capture any error which originates from outside of our code (e.g. an exception from AWS)
+  IntervalSeconds: 3
+  MaxAttempts: 999999
+  BackoffRate: 2

--- a/cloud-formation/src/templates/retries.yaml
+++ b/cloud-formation/src/templates/retries.yaml
@@ -10,7 +10,7 @@ Retry:
   MaxAttempts: 999999 #If we don't provide a value here it defaults to 3
   BackoffRate: 2
 - ErrorEquals:
-  - States.ALL # Wildcard to capture any error which originates from outside of our code (e.g. an exception from AWS)
+  - States.ALL #Wildcard to capture any error which originates from outside of our code (e.g. an exception from AWS)
   IntervalSeconds: 3
   MaxAttempts: 999999
   BackoffRate: 2


### PR DESCRIPTION
## Why are you doing this?

Recently one of our lambdas failed due to an AWS Service exception. Because the [existing retry logic](https://github.com/guardian/support-workers/blob/master/cloud-formation/src/templates/retries.yaml) only handles custom exceptions (which are generated by our own code), we did not retry the task execution. 

Similarly, if an exception is thrown before the handler is invoked (e.g. if AWS cannot find the handler function at all), or if a Lambda times out, our current logic would fail to trigger retries.

This PR adds a catch-all for these cases, based on the [AWS documentation](http://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html).

As far as I can tell this works like a pattern match in Scala, so the generic retry rule is only reached if the more specific errors are not found. (I tested this out to prove it to myself - more details in the Trello card).

[**Trello Card**](https://trello.com/c/NbYIcJO0/1132-add-error-handling-for-exceptions-which-occur-outside-of-our-own-code)

## Changes

* Retry exceptions which occur due to external factors indefinitely (in reality, these executions will be stopped by the timeout added [here](https://github.com/guardian/support-workers/pull/81)).

