### PR TITLE
Explicitly set retries to 0 for RetryNone

### DIFF
--- a/cloud-formation/src/templates/retries.yaml
+++ b/cloud-formation/src/templates/retries.yaml
@@ -1,5 +1,8 @@
 Retry:
 - ErrorEquals:
+  - com.gu.support.workers.exceptions.RetryNone
+  MaxAttempts: 0
+- ErrorEquals:
   - com.gu.support.workers.exceptions.RetryLimited
   IntervalSeconds: 1
   MaxAttempts: 3


### PR DESCRIPTION
## Why are you doing this?

The catch-all retry case I added [here](https://github.com/guardian/support-workers/pull/82) means that we are repeatedly retrying when we throw a com.gu.support.workers.exceptions.RetryNone.

This PR stops us from doing that.

cc @davidfurey @rupertbates 
