### PR TITLE
Send a Stripe-Version header if configured and expect the new Customer model from Stripe

### DIFF
--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -48,24 +48,24 @@ object Stripe {
     implicit val codec: Codec[Card] = deriveCodec
   }
 
-  case class Card(id: String, `type`: String, last4: String, exp_month: Int, exp_year: Int, country: String) extends StripeObject {
-    val issuer = `type`.toLowerCase
+  case class Card(id: String, brand: String, last4: String, exp_month: Int, exp_year: Int, country: String) extends StripeObject {
+    val issuer = brand.toLowerCase
     // Zuora requires 'AmericanExpress' not 'American Express'
     // See CreditCardType at https://www.zuora.com/developer/api-reference/#operation/Object_POSTPaymentMethod
-    val zuoraCardType = `type`.replaceAll(" ", "")
+    val zuoraCardType = brand.replaceAll(" ", "")
   }
 
   object Customer {
     implicit val codec: Codec[Customer] = deriveCodec
   }
 
-  case class Customer(id: String, cards: StripeList[Card]) extends StripeObject {
+  case class Customer(id: String, sources: StripeList[Card]) extends StripeObject {
     // customers should always have a card
-    if (cards.total_count != 1) {
-      throw StripeError("internal", s"Customer $id has ${cards.total_count} cards, should have exactly one")
+    if (sources.total_count != 1) {
+      throw StripeError("internal", s"Customer $id has ${sources.total_count} cards, should have exactly one")
     }
 
-    val card = cards.data.head
+    val card = sources.data.head
   }
 
   object Source {

--- a/common/src/main/scala/com/gu/stripe/Stripe.scala
+++ b/common/src/main/scala/com/gu/stripe/Stripe.scala
@@ -44,11 +44,11 @@ object Stripe {
 
   case class StripeList[T](total_count: Int, data: Seq[T]) extends StripeObject
 
-  object Card {
-    implicit val codec: Codec[Card] = deriveCodec
+  object Source {
+    implicit val codec: Codec[Source] = deriveCodec
   }
 
-  case class Card(id: String, brand: String, last4: String, exp_month: Int, exp_year: Int, country: String) extends StripeObject {
+  case class Source(id: String, brand: String, last4: String, exp_month: Int, exp_year: Int, country: String) extends StripeObject {
     val issuer = brand.toLowerCase
     // Zuora requires 'AmericanExpress' not 'American Express'
     // See CreditCardType at https://www.zuora.com/developer/api-reference/#operation/Object_POSTPaymentMethod
@@ -59,27 +59,13 @@ object Stripe {
     implicit val codec: Codec[Customer] = deriveCodec
   }
 
-  case class Customer(id: String, sources: StripeList[Card]) extends StripeObject {
+  case class Customer(id: String, sources: StripeList[Source]) extends StripeObject {
     // customers should always have a card
     if (sources.total_count != 1) {
       throw StripeError("internal", s"Customer $id has ${sources.total_count} cards, should have exactly one")
     }
 
-    val card = sources.data.head
-  }
-
-  object Source {
-    implicit val codec: Codec[Source] = deriveCodec
-  }
-
-  case class Source(country: String) extends StripeObject
-
-  object Charge {
-    implicit val codec: Codec[Charge] = deriveCodec
-  }
-
-  case class Charge(id: String, amount: Int, balance_transaction: Option[String], created: Int, currency: String, livemode: Boolean,
-      paid: Boolean, refunded: Boolean, receipt_email: String, metadata: Map[String, String], source: Source) extends StripeObject {
+    val source = sources.data.head
   }
 
   object BalanceTransaction {

--- a/common/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/common/src/main/scala/com/gu/stripe/StripeService.scala
@@ -18,13 +18,11 @@ class StripeService(config: StripeConfig, client: FutureHttpClient, baseUrl: Str
   override def wsPreExecute(req: Request.Builder): Request.Builder = {
     req.addHeader("Authorization", s"Bearer ${config.secretKey}")
 
-    config.version match {
-      case Some(version) => {
-        logger.info(s"Making a stripe call with version: $version")
-        req.addHeader("Stripe-Version", version)
-      }
-      case None => req
+    config.version foreach { version =>
+      logger.info(s"Making a stripe call with version: $version")
+      req.addHeader("Stripe-Version", version)
     }
+    req
   }
 
   def createCustomer(description: String, card: String): Future[Customer] =

--- a/common/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/common/src/main/scala/com/gu/stripe/StripeService.scala
@@ -15,8 +15,17 @@ class StripeService(config: StripeConfig, client: FutureHttpClient, baseUrl: Str
   val wsUrl = baseUrl
   val httpClient: FutureHttpClient = client
 
-  override def wsPreExecute(req: Request.Builder): Request.Builder =
+  override def wsPreExecute(req: Request.Builder): Request.Builder = {
     req.addHeader("Authorization", s"Bearer ${config.secretKey}")
+
+    config.version match {
+      case Some(version) => {
+        logger.info(s"Making a stripe call with version: $version")
+        req.addHeader("Stripe-Version", version)
+      }
+      case None => req
+    }
+  }
 
   def createCustomer(description: String, card: String): Future[Customer] =
     post[Customer]("customers", Map(

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -56,7 +56,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     stripeService
       .createCustomer(stripe.userId, stripe.stripeToken)
       .map { stripeCustomer =>
-        val card = stripeCustomer.card
+        val card = stripeCustomer.source
         CreditCardReferenceTransaction(card.id, stripeCustomer.id, card.last4,
           CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, card.zuoraCardType)
       }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -92,7 +92,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec {
     val serviceProvider = mock[ServiceProvider]
     val services = mock[Services]
     val stripe = mock[StripeService]
-    val card = Stripe.Card("1234", "visa", "1234", 1, 2099, "GB")
+    val card = Stripe.Source("1234", "visa", "1234", 1, 2099, "GB")
     val customer = Stripe.Customer("12345", StripeList(1, Seq(card)))
     when(stripe.createCustomer(any[String], any[String])).thenReturn(Future(customer))
     when(services.stripeService).thenReturn(stripe)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val lambdaLogging = "io.symphonia" % "lambda-logging" % "1.0.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.1"
   val supportModels = "com.gu" %% "support-models" % "0.18"
-  val supportConfig = "com.gu" %% "support-config" % "0.6"
+  val supportConfig = "com.gu" %% "support-config" % "0.8"
   val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.1"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % okhttpVersion
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"


### PR DESCRIPTION
## Why are you doing this?
Goal: Be able to test out a newer version of Stripe app by app to remove the element of blind courage currently required to update the version in the Stripe dashboard.

[The Stripe Upgrade Guide](https://stripe.com/docs/upgrades) specifies that the API version used for a given stripe account is the one configured in the dashboard, unless the request has a Stripe-Version header. So, the plan is to send a header Stripe-Version -> 2017-08-15 for the GNM membership account in each relevant app and then up the version in the dashboard.

This change makes it possible to add a stripe version to the config that will be sent on each request to Stripe. 

Additionally, since version [2015-02-18](https://stripe.com/docs/upgrades#2015-02-18), the call to create a customer returns not a list of `cards` but `sources` so I have updated the response we are expecting from Stripe to the one corresponding to version 2017-08-15

Pre merge:
- [x] Test in CODE 
- [x] ensure stripe.api.version = "2017-08-15" is in the config for both CODE and PROD

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/OZ8I3TEN/3-auto-update-card-details-when-card-is-replaced)

## Changes

* On requests to Stripe, we send a version header if there is a version in the Stripe config. 
* Expect the newer Customer response we expect from Stripe after version 2015-02-18
