### PR TITLE
Remove members-data-api step (part 1)

### DIFF
--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -39,13 +39,6 @@ States:
           Resource: "${SendThankYouEmailLambda.Arn}"
           End: True
           {{> retry}}
-    - StartAt: UpdateMembersDataAPI
-      States:
-        UpdateMembersDataAPI:
-          Type: Task
-          Resource: "${UpdateMembersDataAPILambda.Arn}"
-          End: True
-          {{> retry}}
     - StartAt: SendAcquisitionEvent
       States:
         SendAcquisitionEvent:


### PR DESCRIPTION
## Why are you doing this?

Members-data-api now reads directly from Zuora in order to determine a user's attributes. This means that we don't need to trigger a population of the Dynamo table (which the api used to read attributes from) as part of the sign-up flow, so this is a redundant task. It also seems to be one of the most unreliable lambdas in the project, so removing it also provides some reliability benefits.

Note that this is only the first part of this work. It removes the task from the state machine, but leaves the lambda (and related code) in place. This will be removed in a later PR, but needs to stay around when this is merged so that all running executions can complete (without error).

[**Trello Card**](https://trello.com/c/yqxk9rO8/1050-remove-updatemembersdataapi-lambda-from-support-workers)

## Changes

* Remove UpdateMembersDataAPI task from state machine.

