### PR TITLE
Retry on UNKNOWN_ERROR from Zuora

### DIFF
--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -9,6 +9,7 @@ import com.gu.salesforce.Salesforce.SalesforceErrorResponse.expiredAuthenticatio
 import com.gu.stripe.Stripe
 import com.gu.support.workers.exceptions.RetryImplicits._
 import com.gu.support.workers.exceptions._
+import com.gu.zuora.model.response.{ZuoraError, ZuoraErrorResponse}
 import io.circe.ParsingFailure
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -61,5 +62,10 @@ class ErrorHandlerSpec extends FlatSpec with Matchers {
     new InvalidGrantTokenException("").asRetryException shouldBe a[RetryNone]
     new DisabledException("").asRetryException shouldBe a[RetryLimited]
     new AWSKMSException("The security token included in the request is expired").asRetryException shouldBe a[RetryLimited]
+
+    //Zuora
+    ZuoraErrorResponse(false, List(ZuoraError("UNKNOWN_ERROR", "Operation failed due to an unknown error."))).asRetryException shouldBe a[RetryUnlimited]
+    ZuoraErrorResponse(false, List(ZuoraError("TRANSACTION_FAILED", "Your card was declined"))).asRetryException shouldBe a[RetryNone]
+
   }
 }


### PR DESCRIPTION
## Why are you doing this?

We were unable to sign-up new users during a recent [Zuora incident](https://trust.zuora.com/incidents/0yd5tp9k6z10). This PR allows us to cope with the specific problem that we saw (by retrying), should it happen again. 

There are probably a number of other cases that we should consider handling too, but at the moment I can't find any documentation which clearly details all of the expected errors. I'll open a support ticket to ask about this and then open new PRs if necessary.

[**Trello Card**](https://trello.com/c/lSpMrPhN/1211-add-retries-for-known-zuora-errors-which-occur-during-the-createzuorasubscription-task)

## Changes

* Add pattern match to catch 'UNKNOWN_ERROR', and convert to a RetryUnlimited.
* Add Zuora-specific test cases to ErrorHandlerSpec.

