### PR TITLE
Cope with all card errors in FailureHandler

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -55,7 +55,7 @@ class FailureHandler(emailService: EmailService)
         state,
         requestInfo.appendMessage(s"Zuora reported a payment failure: $ze")
       )
-      case Some(se @ StripeError(_, _, Some("card_declined"), _, _)) => returnState(
+      case Some(se @ StripeError("card_error", _, _, _, _)) => returnState(
         state,
         requestInfo.appendMessage(s"Stripe reported a payment failure: ${se.getMessage}")
       )


### PR DESCRIPTION
## Why are you doing this?

At the moment the FailureHandler does not capture all card errors, and this recently led to a false alarm.

[**Trello Card**](https://trello.com/c/2W4yxBW9/1225-cope-with-a-larger-set-of-card-errors-in-failurehandler)

## Changes

* Catch all errors of type 'card_error' in the pattern match, instead of looking for specific card failure codes.

