### PR TITLE
Retry if we hit Salesforce rate limiting errors

### DIFF
--- a/common/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/common/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -1,6 +1,6 @@
 package com.gu.salesforce
 
-import com.gu.salesforce.Salesforce.SalesforceErrorResponse.expiredAuthenticationCode
+import com.gu.salesforce.Salesforce.SalesforceErrorResponse._
 import com.gu.support.workers.encoding.Codec
 import com.gu.support.workers.encoding.Helpers.deriveCodec
 import com.gu.support.workers.exceptions.{RetryException, RetryNone, RetryUnlimited}
@@ -68,10 +68,11 @@ object Salesforce {
   object SalesforceErrorResponse {
     implicit val codec: Codec[SalesforceErrorResponse] = deriveCodec
     val expiredAuthenticationCode = "INVALID_SESSION_ID"
+    val rateLimitExceeded = "REQUEST_LIMIT_EXCEEDED"
   }
 
   case class SalesforceErrorResponse(message: String, errorCode: String) extends Throwable {
-    def asRetryException: RetryException = if (errorCode == expiredAuthenticationCode)
+    def asRetryException: RetryException = if (errorCode == expiredAuthenticationCode || errorCode == rateLimitExceeded)
       new RetryUnlimited(message, cause = this)
     else
       new RetryNone(message, cause = this)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -5,7 +5,7 @@ import java.net.SocketTimeoutException
 import com.amazonaws.services.kms.model._
 import com.gu.paypal.PayPalError
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
-import com.gu.salesforce.Salesforce.SalesforceErrorResponse.expiredAuthenticationCode
+import com.gu.salesforce.Salesforce.SalesforceErrorResponse._
 import com.gu.stripe.Stripe
 import com.gu.support.workers.exceptions.RetryImplicits._
 import com.gu.support.workers.exceptions._
@@ -45,6 +45,7 @@ class ErrorHandlerSpec extends FlatSpec with Matchers {
 
     //Salesforce
     new SalesforceErrorResponse("test", expiredAuthenticationCode).asRetryException shouldBe a[RetryUnlimited]
+    new SalesforceErrorResponse("test", rateLimitExceeded).asRetryException shouldBe a[RetryUnlimited]
     new SalesforceErrorResponse("", "").asRetryException shouldBe a[RetryNone]
 
     //Stripe


### PR DESCRIPTION
## Why are you doing this?

We hit some rate limiting errors from Salesforce this morning: 

```Received response code: 403 | response body: [{"message":"TotalRequests Limit exceeded.","errorCode":"REQUEST_LIMIT_EXCEEDED"}]```

This is not explicitly handled, and therefore caused us to fail several executions.

To some extent adding retries here will exacerbate the problem, but I think the back-off rule means that the impact on our overall limits will not be too significant. I also notice that this is the approach we take for Stripe rate-limiting, so I suggest that we follow the same pattern here.

## Changes

* Treat REQUEST_LIMIT_EXCEEDED error as a RetryUnlimited

