### PR TITLE
Split unit tests and integration tests more effectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ There are a number of integration tests in the project which talk to real servic
 
 These tests are tagged with either an @IntegrationTest annotation at the spec level or an IntegrationTest tag at the individual test level which allows us to run them selectively as follows:
 
-`sbt test` - runs all tests including integration tests.
+`sbt test` - runs unit tests only and excludes integration tests.
 
-`sbt testOnly -- -l com.gu.test.tags.annotations.IntegrationTest` - runs non-integration tests only.
+`sbt it:test` - runs all tests including integration tests.
 
 ## Deployment 
 We use [Riff-Raff](https://github.com/guardian/riff-raff) to deploy this project to production each time a new change is merged to master.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,9 +23,9 @@ object Dependencies {
   val awsSQS = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
   val awsStepFunctions = "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-  val mokito = "org.mockito" % "mockito-core" % "1.9.5" % "test"
-  val mockWebserver = "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % "it,test"
+  val mokito = "org.mockito" % "mockito-core" % "1.9.5" % "it,test"
+  val mockWebserver = "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "it,test"
   val circeCore = "io.circe" %% "circe-core" % circeVersion
   val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   val circeGenericExtras = "io.circe" %% "circe-generic-extras" % circeVersion

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,4 +10,10 @@ object Settings {
     scalaVersion := "2.11.8",
     scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
   )
+
+  val testSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
+    scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
+    javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
+    testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"))
+  )
 }


### PR DESCRIPTION
## Why are you doing this?
With the current SBT configuration it is hard to run the integration tests from the command line because they are excluded by default to prevent them failing on TeamCity (it doesn't have the necessary credentials to run them).

This PR adds a new `IntegrationTest` configuration which allows us to run `sbt test` to run only unit tests or `sbt it:test` to run all tests including integration tests


[**Trello Card**](https://trello.com/c/4Oz8P5MI/1234-find-a-way-to-avoid-running-integration-tests-on-teamcity-for-support-workers)

