### PR TITLE
Handle decoding errors better in the decoder.sh script

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
@@ -14,7 +14,8 @@ import scala.util.Try
 object StateDecoder extends App with LazyLogging {
 
   if (args.length < 1) {
-    print("Please pass in the Json state and optionally the AWS encryption key ARN if different from the DEV config")
+    //scalastyle:off regex
+    println("Please pass in the Json state and optionally the AWS encryption key ARN if different from the DEV config")
   }
 
   decode[JsonWrapper](args(0)).fold(println(_), { jsonWrapper =>

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
@@ -17,21 +17,22 @@ object StateDecoder extends App with LazyLogging {
     print("Please pass in the Json state and optionally the AWS encryption key ARN if different from the DEV config")
   }
 
-  val jsonWrapper = decode[JsonWrapper](args(0)).right.get
-  val awsEncryptionKeyId = Try(args(1)).getOrElse(Configuration.encryptionKeyId)
+  decode[JsonWrapper](args(0)).fold(println(_), { jsonWrapper =>
+    val awsEncryptionKeyId = Try(args(1)).getOrElse(Configuration.encryptionKeyId)
 
-  val decoded = Base64.getDecoder.decode(jsonWrapper.state)
+    val decoded = Base64.getDecoder.decode(jsonWrapper.state)
 
-  if (jsonWrapper.requestInfo.encrypted)
-    decryptState(decoded)
-  else
-    print(new String(decoded, utf8))
+    if (jsonWrapper.requestInfo.encrypted)
+      decryptState(decoded)
+    else
+      print(new String(decoded, utf8))
 
-  def decryptState(state: Array[Byte]): Unit = {
-    val config = new AwsConfig(true, awsEncryptionKeyId)
-    val encoder = new AwsEncryptionProvider(awsEncryptionKeyId)
-    print(encoder.decrypt(state))
-  }
+    def decryptState(state: Array[Byte]): Unit = {
+      val config = new AwsConfig(true, awsEncryptionKeyId)
+      val encoder = new AwsEncryptionProvider(awsEncryptionKeyId)
+      print(encoder.decrypt(state))
+    }
+  })
 
   def print(output: String): Unit = println(s"\n\n$output\n\n") // scalastyle:ignore
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -210,4 +210,20 @@ object Fixtures {
       }
     """
 
+  val wrapperWithMessages =
+    """
+      {
+        "state": "eyJyZXF1ZXN0SWQiOiIxNjVhMjk1NS00YTE4LTIzYWUtMDAwMC0wMDAwMDAwMDAwMDQiLCJ1c2VyIjp7ImlkIjoiMzAwMDIxNzciLCJwcmltYXJ5RW1haWxBZGRyZXNzIjoiZGxhc2RqQGRhc2QuY29tIiwiZmlyc3ROYW1lIjoic29tZXRoaW5nIiwibGFzdE5hbWUiOiJibGEiLCJjb3VudHJ5IjoiR0IiLCJzdGF0ZSI6bnVsbCwiYWxsb3dNZW1iZXJzaGlwTWFpbCI6ZmFsc2UsImFsbG93VGhpcmRQYXJ0eU1haWwiOmZhbHNlLCJhbGxvd0dVUmVsYXRlZE1haWwiOmZhbHNlLCJpc1Rlc3RVc2VyIjpmYWxzZX0sImNvbnRyaWJ1dGlvbiI6eyJhbW91bnQiOjMuNTIsImN1cnJlbmN5IjoiR0JQIiwiYmlsbGluZ1BlcmlvZCI6Ik1vbnRobHkifSwicGF5bWVudE1ldGhvZCI6eyJUb2tlbklkIjoiY2FyZF9DR2dWYUxzVENpdnFLdCIsIlNlY29uZFRva2VuSWQiOiJjdXNfQ0dnVlFnc0dGcWdQYlciLCJDcmVkaXRDYXJkTnVtYmVyIjoiNDI0MiIsIkNyZWRpdENhcmRDb3VudHJ5IjoiVVMiLCJDcmVkaXRDYXJkRXhwaXJhdGlvbk1vbnRoIjoxMiwiQ3JlZGl0Q2FyZEV4cGlyYXRpb25ZZWFyIjoyMDIxLCJDcmVkaXRDYXJkVHlwZSI6IlZpc2EiLCJUeXBlIjoiQ3JlZGl0Q2FyZFJlZmVyZW5jZVRyYW5zYWN0aW9uIn0sImFjcXVpc2l0aW9uRGF0YSI6eyJvcGhhbklkcyI6eyJwYWdldmlld0lkIjoiamRhNzQweWg3ZXJmYXdwenpmOW0iLCJ2aXNpdElkIjpudWxsLCJicm93c2VySWQiOm51bGx9LCJyZWZlcnJlckFjcXVpc2l0aW9uRGF0YSI6eyJjYW1wYWlnbkNvZGUiOm51bGwsInJlZmVycmVyUGFnZXZpZXdJZCI6bnVsbCwicmVmZXJyZXJVcmwiOm51bGwsImNvbXBvbmVudElkIjpudWxsLCJjb21wb25lbnRUeXBlIjpudWxsLCJzb3VyY2UiOm51bGwsImFiVGVzdCI6bnVsbH0sInN1cHBvcnRBYlRlc3RzIjpbeyJuYW1lIjoidXNTZWN1cmVMb2dvVGVzdCIsInZhcmlhbnQiOiJub3RpbnRlc3QifV19fQ==",
+        "error": null,
+        "requestInfo": {
+          "encrypted": false,
+          "testUser": false,
+          "failed": false,
+          "messages": [
+            "Payment method is Stripe"
+          ]
+        }
+      }
+    """
+
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,8 +1,11 @@
 package com.gu.support.workers
 
 import com.gu.support.workers.Fixtures.{contribution, wrapFixture}
+import com.gu.support.workers.encoding.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Encoding
+import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.monthlyContributions.Contribution
+import com.gu.support.workers.model.monthlyContributions.state.CreateSalesforceContactState
 import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
@@ -12,6 +15,11 @@ class WrapperSpec extends FlatSpec with Matchers with LazyLogging {
     val wrapped = wrapFixture(contribution())
 
     val result = Encoding.in[Contribution](wrapped)
+    result.isSuccess should be(true)
+  }
+  it should "be able to handle a JsonWrapper with messages" in {
+    val result = Encoding.in[CreateSalesforceContactState](Fixtures.wrapperWithMessages.asInputStream)
+    logger.info(s"$result")
     result.isSuccess should be(true)
   }
 }


### PR DESCRIPTION
## Why are you doing this?

Currently if decoding fails in the decode.sh script we don't get any diagnostic information, this PR changes that.