### PR TITLE
Handle SocketExceptions

### DIFF
--- a/common/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/common/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.exceptions
 
-import java.net.SocketTimeoutException
-
+import java.net.{SocketException, SocketTimeoutException}
 import com.amazonaws.services.kms.model._
 import com.amazonaws.services.sqs.model.{AmazonSQSException, InvalidMessageContentsException, QueueDoesNotExistException}
 import com.gu.acquisition.model.errors.OphanServiceError
@@ -12,9 +11,8 @@ object RetryImplicits {
 
   implicit class RetryConversions(val throwable: Throwable) {
     def asRetryException: RetryException = throwable match {
-      //timeouts and 500s
-      case e @ (_: SocketTimeoutException |
-        _: WebServiceHelperError[_]) => new RetryUnlimited(message = e.getMessage, cause = throwable)
+      //Timeouts/connection issues and 500s
+      case e @ (_: SocketTimeoutException | _: SocketException | _: WebServiceHelperError[_]) => new RetryUnlimited(message = e.getMessage, cause = throwable)
 
       //Invalid Json
       case e: ParsingFailure => new RetryNone(message = e.getMessage, cause = throwable)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.errors
 
-import java.net.SocketTimeoutException
-
+import java.net.{SocketException, SocketTimeoutException}
 import com.amazonaws.services.kms.model._
 import com.gu.paypal.PayPalError
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
@@ -23,6 +22,12 @@ class ErrorHandlerSpec extends FlatSpec with Matchers {
   "ErrorHandler" should "throw an RetryUnlimited when it handles a timeout" in {
     an[RetryUnlimited] should be thrownBy {
       ErrorHandler.handleException(new SocketTimeoutException())
+    }
+  }
+
+  "ErrorHandler" should "throw an RetryUnlimited when the connection is reset" in {
+    an[RetryUnlimited] should be thrownBy {
+      ErrorHandler.handleException(new SocketException())
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

We recently failed to sign up a user during a period of Salesforce downtime. This is because we treated the [exception](https://sentry.io/the-guardian/support-workers/issues/457711827/) as a RetryLimited, rather than a RetryUnlimited. In my opinion we should treat SocketExceptions in the same way that we treat SocketTimeoutExceptions, with respect to retries. 

## Changes

* Add explicit handling for SocketExceptions 

