### PR TITLE
Add retries to FailureHandler task

### DIFF
--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -52,6 +52,7 @@ States:
     Type: Task
     Resource: "${FailureHandlerLambda.Arn}"
     Next: SucceedOrFailChoice
+    {{> retry}}
 
   SucceedOrFailChoice:
     Type: Choice


### PR DESCRIPTION
## Why are you doing this?

This should help to ensure that users who fail to sign-up always receive an email. It should also cut down on the noise from our AWS alerts, as currently if this lambda fails we get an alert due to the Step Function execution failing.

I've set up some temporary alerting on the two lambdas which are timing out, so that I can continue debugging this without spamming a huge mailing list. (Full details on approach can be found in the Trello card).

[**Trello Card**](https://trello.com/c/Fh3vvzo7/1296-add-retries-to-cope-with-cases-where-failurehandler-throws-lambdaunknown-errors)

## Changes

* Use the standard [retry rules](https://github.com/guardian/support-workers/blob/master/cloud-formation/src/templates/retries.yaml) for the FailureHandler.

