### PR TITLE
Change retry rules for lambdas which send an email

### DIFF
--- a/cloud-formation/src/build-cfn.js
+++ b/cloud-formation/src/build-cfn.js
@@ -9,6 +9,7 @@ try { fs.mkdirSync('../target'); } catch(err) { }
 //converted to Json before inclusion in the final cfn output
 let partials = {
   retry: loadTemplate('retries.yaml'),
+  emailRetry: loadTemplate('emailRetries.yaml'),
   catch: loadTemplate('catch.yaml')
 }
 const stateMachine = Handlebars.compile(loadTemplate('state-machine.yaml'))

--- a/cloud-formation/src/templates/emailRetries.yaml
+++ b/cloud-formation/src/templates/emailRetries.yaml
@@ -6,4 +6,3 @@ Retry:
   - States.ALL #Wildcard to capture any other error, including those with originate from outside of our code (e.g. an exception from AWS)
   IntervalSeconds: 60
   MaxAttempts: 1
-  BackoffRate: 2

--- a/cloud-formation/src/templates/emailRetries.yaml
+++ b/cloud-formation/src/templates/emailRetries.yaml
@@ -1,0 +1,9 @@
+Retry:
+- ErrorEquals:
+  - com.gu.support.workers.exceptions.RetryNone
+  MaxAttempts: 0
+- ErrorEquals:
+  - States.ALL #Wildcard to capture any other error, including those with originate from outside of our code (e.g. an exception from AWS)
+  IntervalSeconds: 60
+  MaxAttempts: 1
+  BackoffRate: 2

--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -38,7 +38,7 @@ States:
           Type: Task
           Resource: "${SendThankYouEmailLambda.Arn}"
           End: True
-          {{> retry}}
+          {{> emailRetry}}
     - StartAt: SendAcquisitionEvent
       States:
         SendAcquisitionEvent:
@@ -52,6 +52,7 @@ States:
     Type: Task
     Resource: "${FailureHandlerLambda.Arn}"
     Next: SucceedOrFailChoice
+    {{> emailRetry}}
 
   SucceedOrFailChoice:
     Type: Choice


### PR DESCRIPTION
## Why are you doing this?
This PR makes it more likely that users who fail to sign-up will receive an email. It should also cut down on the noise from our AWS alerts, as currently if this lambda fails we get an alert due to the Step Function execution failing.

I've set up some temporary alerting on the two lambdas which are timing out, so that I can continue debugging this without spamming a huge mailing list. (Full details on approach can be found in the Trello card).

This PR also makes us slightly more conservative about retrying the lambda which sends users a thankyou email - at worst we will now send them two emails, whereas before we could have introduced a bug which would have led to us spamming users for up to 24 hours.

Some docs on task retries can be found here: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-errors.html

[**Trello Card**](https://trello.com/c/Fh3vvzo7/1296-stop-failurehandler-from-throwing-lambdaunknown-errors)

## Changes

* Add a separate emailRetries.yaml
* Use this as the retry rule for SendThankYouEmailLambda and FailureHandlerLambda (both of these send emails)

I've tested deploying this to CODE with riff-raff.