### PR TITLE
Add more logging to the email service

### DIFF
--- a/common/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -6,8 +6,8 @@ import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
 import com.gu.aws.{AwsAsync, CredentialsProvider}
 import com.typesafe.scalalogging.StrictLogging
 import org.joda.time.DateTime
-
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
 case class EmailFields(

--- a/common/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -8,6 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import org.joda.time.DateTime
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 case class EmailFields(
     email: String,
@@ -52,7 +53,12 @@ class EmailService(config: EmailConfig) extends StrictLogging {
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
     logger.info(s"Sending message to SQS queue $queueUrl")
-    AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, fields.payload(config.dataExtensionName)))
+    val messageResult = AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, fields.payload(config.dataExtensionName)))
+    messageResult.onComplete {
+      case Success(result) => logger.info(s"Successfully sent message to $queueUrl: $result")
+      case Failure(throwable) => logger.error(s"Failed to send message due to $queueUrl due to:", throwable)
+    }
+    messageResult
   }
 
 }


### PR DESCRIPTION
## Why are you doing this?
This is a follow up to https://github.com/guardian/support-workers/pull/102.

[**Trello Card**](https://trello.com/c/Fh3vvzo7/1296-add-retries-to-cope-with-cases-where-failurehandler-throws-lambdaunknown-errors)

## Changes
* Log the result when sending a message to SQS

