### PR TITLE
Add even more logging to help understand task timeouts

### DIFF
--- a/common/src/main/scala/com/gu/aws/AWSAsyncHandler.scala
+++ b/common/src/main/scala/com/gu/aws/AWSAsyncHandler.scala
@@ -19,7 +19,7 @@ class AwsAsyncHandler[Request <: AmazonWebServiceRequest, Response](f: (Request,
     exception match {
       case e: AmazonServiceException =>
         if (e.getErrorCode == "ThrottlingException") {
-          logger.warn(s"A rate limiting exception was thrown, we may need to adjust the rate limiting in ClientWrapper.scala")
+          logger.warn("A rate limiting exception was thrown, we may need to adjust the rate limiting in ClientWrapper.scala")
           Thread.sleep(1000) //Wait for a second and retry
           f(request, this)
         } else {

--- a/common/src/main/scala/com/gu/aws/AWSAsyncHandler.scala
+++ b/common/src/main/scala/com/gu/aws/AWSAsyncHandler.scala
@@ -15,7 +15,7 @@ class AwsAsyncHandler[Request <: AmazonWebServiceRequest, Response](f: (Request,
   private val promise = Promise[Response]()
 
   override def onError(exception: Exception): Unit = {
-    logger.warn(s"Failure from AWSAsyncHandler", exception)
+    logger.warn("Failure from AWSAsyncHandler", exception)
     exception match {
       case e: AmazonServiceException =>
         if (e.getErrorCode == "ThrottlingException") {

--- a/common/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/common/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -40,7 +40,7 @@ case class EmailFields(
     """.stripMargin
 }
 
-class EmailService(config: EmailConfig, executionContext: ExecutionContext) extends StrictLogging {
+class EmailService(config: EmailConfig, implicit val executionContext: ExecutionContext) extends StrictLogging {
 
   private val sqsClient = AmazonSQSAsyncClientBuilder
     .standard
@@ -49,8 +49,6 @@ class EmailService(config: EmailConfig, executionContext: ExecutionContext) exte
     .build()
 
   private val queueUrl = sqsClient.getQueueUrl(config.queueName).getQueueUrl
-
-  implicit val ec = executionContext
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
     logger.info(s"Sending message to SQS queue $queueUrl")

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class FailureHandler(emailService: EmailService)
     extends FutureHandler[FailureHandlerState, CompletedState]
     with LazyLogging {
-  def this() = this(new EmailService(Configuration.emailServicesConfig.failed))
+  def this() = this(new EmailService(Configuration.emailServicesConfig.failed, global))
 
   override protected def handlerFuture(
     state: FailureHandlerState,

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -9,13 +9,12 @@ import com.gu.support.workers.model.{ExecutionError, RequestInfo}
 import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SendThankYouEmail(thankYouEmailService: EmailService)
     extends FutureHandler[SendThankYouEmailState, Unit] with LazyLogging {
 
-  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou))
+  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, global))
 
   override protected def handlerFuture(
     state: SendThankYouEmailState,

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -17,7 +17,6 @@ import com.gu.zuora.encoding.CustomCodecs._
 import com.gu.zuora.model.response.{ZuoraError, ZuoraErrorResponse}
 import io.circe.parser.decode
 import org.joda.time.DateTime
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.io.Source
 
@@ -25,7 +24,7 @@ import scala.io.Source
 class FailureHandlerSpec extends LambdaSpec {
 
   "EmailService" should "send a failure email" in {
-    val service = new EmailService(Configuration.emailServicesConfig.failed)
+    val service = new EmailService(Configuration.emailServicesConfig.failed, global)
     val email = "rupert.bates@theguardian.com"
     service
       .send(EmailFields(email, DateTime.now(), 5, "GBP", "UK", "", "monthly-contribution"))


### PR DESCRIPTION
## Why are you doing this?

Because I still can't debug the email task timeouts...

[**Trello Card**](https://trello.com/c/Fh3vvzo7/1296-stop-failurehandler-from-throwing-lambdaunknown-errors)

## Changes
* Add logging to AWSAsyncHandler, so we can ascertain whether we get a response from AWS
* Move from onComplete to recover/map, to ensure that the email service logging completes before the lambda exits
* EmailService class now accepts an execution context

