### PR TITLE
Configure thread pool for thank you email lambda

### DIFF
--- a/common/src/main/scala/com/gu/threadpools/CustomPool.scala
+++ b/common/src/main/scala/com/gu/threadpools/CustomPool.scala
@@ -1,0 +1,11 @@
+package com.gu.threadpools
+
+import java.util.concurrent.Executors
+import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.ExecutionContext
+
+object CustomPool extends StrictLogging {
+
+  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+
+}

--- a/common/src/main/scala/com/gu/threadpools/CustomPool.scala
+++ b/common/src/main/scala/com/gu/threadpools/CustomPool.scala
@@ -1,11 +1,10 @@
 package com.gu.threadpools
 
 import java.util.concurrent.Executors
-import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.ExecutionContext
 
-object CustomPool extends StrictLogging {
+object CustomPool {
 
-  implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+  implicit val executionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
 
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -9,12 +9,14 @@ import com.gu.support.workers.model.{ExecutionError, RequestInfo}
 import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
-import scala.concurrent.ExecutionContext.Implicits.global
+import com.gu.threadpools.CustomPool.ec
 
 class SendThankYouEmail(thankYouEmailService: EmailService)
     extends FutureHandler[SendThankYouEmailState, Unit] with LazyLogging {
 
-  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, global))
+  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, ec))
+
+  logger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
 
   override protected def handlerFuture(
     state: SendThankYouEmailState,

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -9,12 +9,12 @@ import com.gu.support.workers.model.{ExecutionError, RequestInfo}
 import com.gu.zuora.encoding.CustomCodecs._
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
-import com.gu.threadpools.CustomPool.ec
+import com.gu.threadpools.CustomPool.executionContext
 
 class SendThankYouEmail(thankYouEmailService: EmailService)
     extends FutureHandler[SendThankYouEmailState, Unit] with LazyLogging {
 
-  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, ec))
+  def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, executionContext))
 
   logger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
 


### PR DESCRIPTION
## Why are you doing this?

Since we're running in a lambda with relatively limited resources, the max number of threads available (when using the global execution context) is always likely to be pretty low. We think that the lambda timeouts that we're seeing may be due to thread contention, so this PR attempts to test that theory.

[**Trello Card**](https://trello.com/c/Fh3vvzo7/1296-stop-failurehandler-from-throwing-lambdaunknown-errors)

## Changes

* Configure new execution context with fixed thread pool
* Log the number of available processors to help with debugging (see https://docs.scala-lang.org/overviews/core/futures.html#the-global-execution-context)
