### PR TITLE
Send query parameters in ophan event

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -76,7 +76,8 @@ object SendAcquisitionEvent {
               componentId = data.referrerAcquisitionData.componentId,
               componentTypeV2 = data.referrerAcquisitionData.componentType,
               source = data.referrerAcquisitionData.source,
-              platform = Some(ophan.thrift.event.Platform.Support)
+              platform = Some(ophan.thrift.event.Platform.Support),
+              queryParameters = data.referrerAcquisitionData.queryParameters
             )
           },
           "acquisition data not included"


### PR DESCRIPTION
## Why are you doing this?
Following on from https://github.com/guardian/support-workers/pull/111, we want to send the query parameters field to ophan

@guardian/contributions 