### PR TITLE
Remove identityid from stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These tests are tagged with either an @IntegrationTest annotation at the spec le
 
 `sbt it:test` - runs all tests including integration tests.
 
-## Deployment 
+## Deployment
 We use [Riff-Raff](https://github.com/guardian/riff-raff) to deploy this project to production each time a new change is merged to master.
 
 The following steps happen as part of a deployment:
@@ -60,7 +60,7 @@ The following steps happen as part of a deployment:
 1. (If necessary) Cloudformation updates are applied in AWS. For example, if your change removes a task from the Step Function, or deletes one of the Lambdas, Riff-Raff triggers a change to the underlying AWS resources.
 2. The .jar used by each of the Lambdas defined in this project is updated, meaning that all future Lambda invocations will run code which contains the new changes.
 
-It's important to be aware that some Step Function executions may still be in progress when new changes are deployed. This means that all changes merged to master should be backwards compatible for old executions (i.e. executions which depend on the resources from the old Cloudformation template, and the old versions of the Lambda functions). 
+It's important to be aware that some Step Function executions may still be in progress when new changes are deployed. This means that all changes merged to master should be backwards compatible for old executions (i.e. executions which depend on the resources from the old Cloudformation template, and the old versions of the Lambda functions).
 
 Examples of changes which could break existing executions include editing the JSON structure which is passed between two of the Lambdas, or deleting a Lambda from the Cloudformation template. In such cases, it's often necessary to split changes into two PRs. The initial PR is used to transition all future executions to use only the new code or resources, and a second PR is used to tidy up, after ensuring that all running executions are now using the new JSON structure or Step Function definition.
 
@@ -105,7 +105,7 @@ If you want to look at the input to a particular state machine execution you can
     __(note the single quotes around the json, these are necessary or quotes get stripped out)__
 
     The output should be something like:
-    `{"requestId":"9759a67f-61a7-10c6-0000-00000000008c","user":{"id":"30001273","primaryEmailAddress":"dslkjfsdlk@gu.com","firstName":"tstssdd","lastName":"ljsdlfkjsdflkj","country":"GB","state":null,"allowMembershipMail":false,"allowThirdPartyMail":false,"allowGURelatedMail":true,"isTestUser":false},"contribution":{"amount":5,"currency":"GBP","billingPeriod":"Monthly"},"paymentFields":{"userId":"30001273","stripeToken":"tok_BWg0DWRgTkyCY7"}}`
+    `{"requestId":"9759a67f-61a7-10c6-0000-00000000008c","user":{"id":"30001273","primaryEmailAddress":"dslkjfsdlk@gu.com","firstName":"tstssdd","lastName":"ljsdlfkjsdflkj","country":"GB","state":null,"allowMembershipMail":false,"allowThirdPartyMail":false,"allowGURelatedMail":true,"isTestUser":false},"contribution":{"amount":5,"currency":"GBP","billingPeriod":"Monthly"},"paymentFields":{"stripeToken":"tok_BWg0DWRgTkyCY7"}}`
 
 By default the script will use the AWS encryption key ARN from the local support-workers.private.conf, this is fine
 for decrypting state from the CODE environment but if you want to decrypt state from PROD, you can pass the

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import sbt.Keys.{libraryDependencies, resolvers}
-
 import scalariform.formatter.preferences.SpacesAroundMultiImports
 
 scalaVersion := "2.12.4"
@@ -41,7 +40,7 @@ lazy val common = project
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.0",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.25",
+      "com.gu" %% "support-models" % "0.26",
       "com.gu" %% "support-config" % "0.16",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
       "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -44,11 +44,11 @@ touchpoint.backend.environments {
 
 email {
   thankYou {
-    queueName=contributions-thanks-dev
+    queueName=contributions-thanks
     dataExtensionName=regular-contribution-thank-you
   }
   failed {
-    queueName=contributions-thanks-dev
+    queueName=contributions-thanks
     dataExtensionName=contribution-failed
   }
 }

--- a/common/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/common/src/main/scala/com/gu/stripe/StripeService.scala
@@ -15,10 +15,9 @@ class StripeService(config: StripeConfig, client: FutureHttpClient, baseUrl: Str
   val wsUrl = baseUrl
   val httpClient: FutureHttpClient = client
 
-  def createCustomer(description: String, card: String, currency: Currency): Future[Customer] =
+  def createCustomer(token: String, currency: Currency): Future[Customer] =
     postForm[Customer]("customers", Map(
-      "description" -> Seq(description),
-      "card" -> Seq(card)
+      "card" -> Seq(token)
     ), getHeaders(currency))
 
   private def getHeaders(currency: Currency) =

--- a/common/src/test/scala/com.gu.config/ConfigSpec.scala
+++ b/common/src/test/scala/com.gu.config/ConfigSpec.scala
@@ -29,9 +29,9 @@ class ConfigSpec extends FlatSpec with Matchers with LazyLogging {
     z.url should be("https://rest.apisandbox.zuora.com/v1")
 
     val e = Configuration.emailServicesConfig
-    e.thankYou.queueName should be("contributions-thanks-dev")
+    e.thankYou.queueName should be("contributions-thanks")
     e.thankYou.dataExtensionName should be("regular-contribution-thank-you")
-    e.failed.queueName should be("contributions-thanks-dev")
+    e.failed.queueName should be("contributions-thanks")
     e.failed.dataExtensionName should be("contribution-failed")
   }
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -56,7 +56,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
 
   def createStripePaymentMethod(stripe: StripePaymentFields, currency: Currency, stripeService: StripeService): Future[CreditCardReferenceTransaction] =
     stripeService
-      .createCustomer(stripe.userId, stripe.stripeToken, currency)
+      .createCustomer(stripe.stripeToken, currency)
       .map { stripeCustomer =>
         val card = stripeCustomer.source
         CreditCardReferenceTransaction(card.id, stripeCustomer.id, card.last4,

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -64,7 +64,6 @@ object Fixtures {
   val stripeJson =
     s"""
                 {
-                  "userId": "12345",
                   "stripeToken": "$stripeToken"
                 }
                 """

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -83,7 +83,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
   "StripeService" should "throw a card_declined StripeError" taggedAs IntegrationTest in {
     val service = new StripeService(Configuration.stripeConfigProvider.get(true), configurableFutureRunner(40.seconds))
     val ex = recoverToExceptionIf[StripeError] {
-      service.createCustomer("Test", "tok_chargeDeclined", GBP)
+      service.createCustomer("tok_chargeDeclined", GBP)
     }
     ex.map(_.code should be(Some("card_declined")))
   }
@@ -95,7 +95,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
     val stripe = mock[StripeService]
     val card = Stripe.Source("1234", "visa", "1234", 1, 2099, "GB")
     val customer = Stripe.Customer("12345", StripeList(1, Seq(card)))
-    when(stripe.createCustomer(any[String], any[String], any[Currency])).thenReturn(Future(customer))
+    when(stripe.createCustomer(any[String], any[Currency])).thenReturn(Future(customer))
     when(services.stripeService).thenReturn(stripe)
     when(serviceProvider.forUser(any[Boolean])).thenReturn(services)
     serviceProvider

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -43,7 +43,6 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
     val stripe = decode[StripePaymentFields](stripeJson)
     val stripePaymentFields = stripe.right.get
 
-    stripePaymentFields.userId should be("12345")
     stripePaymentFields.stripeToken should be(stripeToken)
 
     val payPal = decode[PayPalPaymentFields](payPalJson)

--- a/scripts/decode.sh
+++ b/scripts/decode.sh
@@ -13,7 +13,7 @@ This script allows you to decrypt the state from step function executions, it ca
 
     The output should be something like:
 
-    `{"requestId":"9759a67f-61a7-10c6-0000-00000000008c","user":{"id":"30001273","primaryEmailAddress":"dslkjfsdlk@gu.com","firstName":"tstssdd","lastName":"ljsdlfkjsdflkj","country":"GB","state":null,"allowMembershipMail":false,"allowThirdPartyMail":false,"allowGURelatedMail":true,"isTestUser":false},"contribution":{"amount":5,"currency":"GBP","billingPeriod":"Monthly"},"paymentFields":{"userId":"30001273","stripeToken":"tok_BWg0DWRgTkyCY7"}}`
+    `{"requestId":"9759a67f-61a7-10c6-0000-00000000008c","user":{"id":"30001273","primaryEmailAddress":"dslkjfsdlk@gu.com","firstName":"tstssdd","lastName":"ljsdlfkjsdflkj","country":"GB","state":null,"allowMembershipMail":false,"allowThirdPartyMail":false,"allowGURelatedMail":true,"isTestUser":false},"contribution":{"amount":5,"currency":"GBP","billingPeriod":"Monthly"},"paymentFields":{"stripeToken":"tok_BWg0DWRgTkyCY7"}}`
 
     By default the script will use the AWS encryption key ARN from the local support-workers.private.conf, this is fine
     for decrypting state from the CODE environment but if you want to decrypt state from PROD, you can pass the


### PR DESCRIPTION
## Why are you doing this?
Currently when a user signs up with a credit card we send their Identity ID in the description field when creating the Stripe customer record. For GDPR reasons we need to stop doing this.

I have tested this on code and it works without any changes to support-frontend so can be released first.

[**Trello Card**](https://trello.com/c/rNWSgTCY/1363-investigate-data-sent-to-stripe)
