### PR TITLE
Wait for email result before allowing handler to exit

### DIFF
--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -28,9 +28,10 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
     services: Services
   ): FutureHandlerResult = {
     logger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
-    fetchDirectDebitMandateId(state, services.zuoraService)
-      .map(id => sendEmail(state, id))
-      .map(_ => HandlerResult(Unit, requestInfo))
+    for {
+      mandateId <- fetchDirectDebitMandateId(state, services.zuoraService)
+      emailResult <- sendEmail(state, mandateId)
+    } yield HandlerResult(Unit, requestInfo)
   }
 
   def fetchDirectDebitMandateId(state: SendThankYouEmailState, zuoraService: ZuoraService): Future[Option[String]] = state.paymentMethod match {


### PR DESCRIPTION
## Why are you doing this?

We are not currently waiting for the asynchronous call which puts an email message onto an SQS queue. This means that the handler can exit before we've confirmed that the result from AWS was successful.

Although we wait for a Future to complete [here](https://github.com/guardian/support-workers/blob/980394a0e8a2f112a30bb5069af1a160c6a8d694/common/src/main/scala/com/gu/support/workers/lambdas/Handler.scala#L46-L51), we have ended up with nested Futures and were discarding the one that we care about on line 33.

We will have failed to send thank you emails to some recurring contributors since this issue was introduced.



