### PR TITLE
Stop sending PII to Sentry and use SafeLogger everywhere

### DIFF
--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
             <level>ERROR</level>
         </filter>
         <!-- Only send events to the Sentry appender if they've been scrubbed -->
-        <filter class="com.gu.monitoring.SentryFilters.PiiFilter" />
+        <filter class="com.gu.monitoring.PiiFilter" />
     </appender>
 
     <root level="info">

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
             <level>ERROR</level>
         </filter>
         <!-- Only send events to the Sentry appender if they've been scrubbed -->
-        <!--<filter class="com.gu.monitoring.PiiFilter" />-->
+        <filter class="com.gu.monitoring.PiiFilter" />
     </appender>
 
     <root level="info">

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
             <level>ERROR</level>
         </filter>
         <!-- Only send events to the Sentry appender if they've been scrubbed -->
-        <filter class="com.gu.monitoring.PiiFilter" />
+        <!--<filter class="com.gu.monitoring.PiiFilter" />-->
     </appender>
 
     <root level="info">

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,6 +1,12 @@
 <configuration>
 
     <appender name="STDOUT" class="io.symphonia.lambda.logging.DefaultConsoleAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SENTRY</marker>
+            </evaluator>
+            <onMatch>DENY</onMatch>
+        </filter>
 
         <encoder>
             <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %X{AWSRequestId:-NO-REQUEST-ID} %.-6level %logger{5} - %msg%n</pattern>

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,6 +1,7 @@
 <configuration>
 
     <appender name="STDOUT" class="io.symphonia.lambda.logging.DefaultConsoleAppender">
+
         <encoder>
             <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %X{AWSRequestId:-NO-REQUEST-ID} %.-6level %logger{5} - %msg%n</pattern>
         </encoder>
@@ -11,6 +12,8 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
+        <!-- Only send events to the Sentry appender if they've been scrubbed -->
+        <filter class="com.gu.monitoring.SentryFilters.PiiFilter" />
     </appender>
 
     <root level="info">

--- a/common/src/main/scala/com.gu.okhttp/package.scala
+++ b/common/src/main/scala/com.gu.okhttp/package.scala
@@ -2,14 +2,14 @@ package com.gu
 
 import java.io.IOException
 
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import okhttp3._
 
 import scala.concurrent.{Future, Promise}
 
 package object okhttp {
 
-  implicit class RichOkHttpClient(client: OkHttpClient) extends LazyLogging {
+  implicit class RichOkHttpClient(client: OkHttpClient) {
 
     def execute(request: Request): Future[Response] = {
       val p = Promise[Response]()
@@ -17,7 +17,7 @@ package object okhttp {
       client.newCall(request).enqueue(new Callback {
         override def onFailure(call: Call, e: IOException) {
           val sanitizedUrl = s"${request.url().uri().getHost}${request.url().uri().getPath}" // don't log query string
-          logger.warn(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
+          SafeLogger.warn(s"okhttp request failure: ${request.method()} $sanitizedUrl", e)
           p.failure(e)
         }
 

--- a/common/src/main/scala/com/gu/config/Configuration.scala
+++ b/common/src/main/scala/com/gu/config/Configuration.scala
@@ -2,15 +2,15 @@ package com.gu.config
 
 import com.gu.config.loaders.PrivateConfigLoader
 import com.gu.emailservices.EmailServicesConfig
+import com.gu.monitoring.SafeLogger
 import com.gu.salesforce.SalesforceConfigProvider
 import com.gu.support.config._
 import com.gu.zuora.ZuoraConfigProvider
 import com.typesafe.config.ConfigFactory
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
-object Configuration extends LazyLogging {
+object Configuration {
   val loadFromS3: Boolean = Try(Option(System.getenv("GU_SUPPORT_WORKERS_LOAD_S3_CONFIG"))
     .getOrElse("TRUE").toBoolean)
     .getOrElse(true) //Should we load config from S3
@@ -19,7 +19,7 @@ object Configuration extends LazyLogging {
     .getOrElse("DEV"))
     .getOrElse(Stages.DEV)
 
-  logger.info(s"Load from S3: $loadFromS3, Stage: $stage")
+  SafeLogger.info(s"Load from S3: $loadFromS3, Stage: $stage")
 
   val config = PrivateConfigLoader
     .forEnvironment(loadFromS3)

--- a/common/src/main/scala/com/gu/config/loaders/S3Loader.scala
+++ b/common/src/main/scala/com/gu/config/loaders/S3Loader.scala
@@ -4,16 +4,16 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
 import com.gu.aws.CredentialsProvider
+import com.gu.monitoring.SafeLogger
 import com.gu.support.config.Stage
 import com.typesafe.config.{Config, ConfigFactory}
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.io.{BufferedSource, Source}
 
-class S3Loader extends PrivateConfigLoader with LazyLogging {
+class S3Loader extends PrivateConfigLoader {
   override def load(stage: Stage, public: Config): Config = {
     val uri: AmazonS3URI = new AmazonS3URI(public.getString(s"config.private.s3.$stage"))
-    logger.info(s"Loading config from S3 for stage: $stage from $uri")
+    SafeLogger.info(s"Loading config from S3 for stage: $stage from $uri")
     val s3Client = AmazonS3ClientBuilder
       .standard()
       .withCredentials(CredentialsProvider)

--- a/common/src/main/scala/com/gu/helpers/Retry.scala
+++ b/common/src/main/scala/com/gu/helpers/Retry.scala
@@ -1,6 +1,6 @@
 package com.gu.helpers
 
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import dispatch.Defaults.timer
 import dispatch.{retry, _}
 
@@ -8,9 +8,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Failure
 
-object Retry extends LazyLogging {
+object Retry {
   def apply[A](count: Int, errMsg: String = "Error despite retrying: ")(request: => Future[A])(implicit ec: ExecutionContext): Future[A] =
     retry.Backoff(max = count, delay = 2.seconds, base = 2) { () =>
       request.either
-    } flatMap (_.fold(Future.failed, Future.successful)) andThen { case Failure(e) => logger.warn(errMsg, e) }
+    } flatMap (_.fold(Future.failed, Future.successful)) andThen { case Failure(e) => SafeLogger.warn(errMsg, e) }
 }

--- a/common/src/main/scala/com/gu/helpers/Timing.scala
+++ b/common/src/main/scala/com/gu/helpers/Timing.scala
@@ -1,19 +1,19 @@
 package com.gu.helpers
 
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object Timing extends LazyLogging {
+object Timing {
 
   def record[T](service: String, metricName: String)(block: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     val fullName = s"$service $metricName"
-    logger.trace(s"$fullName started...")
+    SafeLogger.debug(s"$fullName started...")
     val startTime = System.currentTimeMillis()
 
     def recordEnd[A](name: String)(a: A): A = {
       val duration = System.currentTimeMillis() - startTime
-      logger.debug(s"$name completed in $duration ms")
+      SafeLogger.debug(s"$name completed in $duration ms")
 
       a
     }

--- a/common/src/main/scala/com/gu/monitoring/CloudWatch.scala
+++ b/common/src/main/scala/com/gu/monitoring/CloudWatch.scala
@@ -6,12 +6,10 @@ import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatc
 import com.gu.aws.{AwsAsync, CredentialsProvider}
 import com.gu.config.Configuration
 import com.gu.monitoring.CloudWatch.client
-import com.typesafe.scalalogging.LazyLogging
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class CloudWatch(metrics: Dimension*) extends LazyLogging {
+class CloudWatch(metrics: Dimension*) {
 
   val application = "SupportWorkers"
   val stageDimension: Dimension = new Dimension().withName("Stage").withValue(Configuration.stage.toString)
@@ -31,11 +29,11 @@ class CloudWatch(metrics: Dimension*) extends LazyLogging {
         .withMetricData(metric)
 
     AwsAsync(client.putMetricDataAsync, request).map { response =>
-      logger.info("CloudWatch PutMetricDataRequest - success")
+      SafeLogger.info("CloudWatch PutMetricDataRequest - success")
       response
     } recoverWith {
       case exception =>
-        logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
+        SafeLogger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
         Future.failed(exception)
     }
   }

--- a/common/src/main/scala/com/gu/monitoring/PiiFilter.scala
+++ b/common/src/main/scala/com/gu/monitoring/PiiFilter.scala
@@ -4,15 +4,15 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
 
-object SentryFilters {
+//object SentryFilters {
 
   class PiiFilter extends Filter[ILoggingEvent] {
     override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
     else FilterReply.DENY
   }
 
-  val piiFilter = new PiiFilter
-
-  piiFilter.start()
-
-}
+//  val piiFilter = new PiiFilter
+//
+//  piiFilter.start()
+//
+//}

--- a/common/src/main/scala/com/gu/monitoring/PiiFilter.scala
+++ b/common/src/main/scala/com/gu/monitoring/PiiFilter.scala
@@ -4,15 +4,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
 
-//object SentryFilters {
-
-  class PiiFilter extends Filter[ILoggingEvent] {
-    override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
-    else FilterReply.DENY
-  }
-
-//  val piiFilter = new PiiFilter
-//
-//  piiFilter.start()
-//
-//}
+class PiiFilter extends Filter[ILoggingEvent] {
+  override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
+  else FilterReply.DENY
+}

--- a/common/src/main/scala/com/gu/monitoring/SafeLogger.scala
+++ b/common/src/main/scala/com/gu/monitoring/SafeLogger.scala
@@ -1,0 +1,46 @@
+package com.gu.monitoring
+
+import com.typesafe.scalalogging.StrictLogging
+import org.slf4j.{Marker, MarkerFactory}
+
+object SafeLogger extends StrictLogging {
+
+  val sanitizedLogMessage: Marker = MarkerFactory.getMarker("SENTRY")
+
+  case class LogMessage(withPersonalData: String, withoutPersonalData: String) {
+    override val toString = withoutPersonalData
+  }
+
+  implicit class Sanitizer(val sc: StringContext) extends AnyVal {
+    def scrub(args: Any*): LogMessage = {
+      LogMessage(sc.s(args: _*), sc.s(args.map(_ => "*****"): _*))
+    }
+  }
+
+  def debug(logMessage: String): Unit = {
+    logger.debug(logMessage)
+  }
+
+  def info(logMessage: String): Unit = {
+    logger.info(logMessage)
+  }
+
+  def warn(logMessage: String): Unit = {
+    logger.warn(logMessage)
+  }
+
+  def warn(logMessage: String, throwable: Throwable): Unit = {
+    logger.warn(logMessage, throwable)
+  }
+
+  def error(logMessage: LogMessage): Unit = {
+    logger.error(logMessage.withPersonalData)
+    logger.error(SafeLogger.sanitizedLogMessage, logMessage.withoutPersonalData)
+  }
+
+  def error(logMessage: LogMessage, throwable: Throwable): Unit = {
+    logger.error(logMessage.withPersonalData, throwable)
+    logger.error(SafeLogger.sanitizedLogMessage, s"${logMessage.withoutPersonalData} due to ${throwable.getCause}")
+  }
+
+}

--- a/common/src/main/scala/com/gu/monitoring/SentryFilters.scala
+++ b/common/src/main/scala/com/gu/monitoring/SentryFilters.scala
@@ -1,0 +1,18 @@
+package com.gu.monitoring
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.filter.Filter
+import ch.qos.logback.core.spi.FilterReply
+
+object SentryFilters {
+
+  class PiiFilter extends Filter[ILoggingEvent] {
+    override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
+    else FilterReply.DENY
+  }
+
+  val piiFilter = new PiiFilter
+
+  piiFilter.start()
+
+}

--- a/common/src/main/scala/com/gu/paypal/PayPalService.scala
+++ b/common/src/main/scala/com/gu/paypal/PayPalService.scala
@@ -3,18 +3,18 @@ package com.gu.paypal
 import java.util.NoSuchElementException
 
 import com.gu.config.Configuration
+import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.support.config.{PayPalConfig, Stages}
 import com.netaporter.uri.QueryString
 import com.netaporter.uri.Uri.parseQuery
-import com.typesafe.scalalogging.LazyLogging
 import okhttp3.{FormBody, Request, Response}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
 
-class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) extends LazyLogging {
+class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) {
 
   val config = apiConfig
   // The parameters sent with every NVP request.
@@ -31,10 +31,10 @@ class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) extends L
     def msg(status: String) = s"PayPal: $status (NVPResponse: $response)"
 
     retrieveNVPParam(response, "ACK") match {
-      case "Success" => logger.info("Successful PayPal NVP request")
-      case "SuccessWithWarning" => logger.warn(msg("Warning"))
-      case "Failure" => logger.warn(msg("Error"))
-      case "FailureWithWarning" => logger.warn(msg("Error With Warning"))
+      case "Success" => SafeLogger.info("Successful PayPal NVP request")
+      case "SuccessWithWarning" => SafeLogger.warn(msg("Warning"))
+      case "Failure" => SafeLogger.warn(msg("Error"))
+      case "FailureWithWarning" => SafeLogger.warn(msg("Error With Warning"))
     }
 
   }
@@ -47,7 +47,7 @@ class PayPalService(apiConfig: PayPalConfig, client: FutureHttpClient) extends L
       throw PayPalError(response.code(), responseBody)
 
     if (Configuration.stage == Stages.DEV)
-      logger.info("NVP response body = " + responseBody)
+      SafeLogger.info("NVP response body = " + responseBody)
 
     val parsedResponse = parseQuery(responseBody)
 

--- a/common/src/main/scala/com/gu/stepfunctions/StepFunctionsService.scala
+++ b/common/src/main/scala/com/gu/stepfunctions/StepFunctionsService.scala
@@ -11,12 +11,12 @@ import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs.createPaymentMethodState
 import com.gu.support.workers.model.User
 import com.gu.support.workers.model.monthlyContributions.state.CreatePaymentMethodState
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class StepFunctionsService extends LazyLogging {
+class StepFunctionsService {
   private val prefix = if (stage == Stages.DEV)
     s"MonthlyContributions${Stages.CODE.toString}-" //There is no DEV state machine
   else
@@ -41,7 +41,7 @@ class StepFunctionsService extends LazyLogging {
     }
 
   private def findUserDataInStateMachine(userId: String, arn: String, nextToken: Option[String] = None)(implicit ec: ExecutionContext): Future[Option[User]] = {
-    logger.info(s"Searching for user in statemachine $arn, nextToken: ${nextToken.getOrElse("")}")
+    SafeLogger.info(s"Searching for user in statemachine $arn, nextToken: ${nextToken.getOrElse("")}")
 
     for {
       response <- client.listExecutions(arn, nextToken)

--- a/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/common/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -7,14 +7,14 @@ import com.gu.salesforce.Salesforce.SalesforceErrorResponse
 import com.gu.stripe.Stripe
 import com.gu.support.workers.exceptions.RetryImplicits._
 import com.gu.zuora.model.response.ZuoraErrorResponse
-import com.typesafe.scalalogging.LazyLogging
-
+import com.gu.monitoring.SafeLogger._
+import com.gu.monitoring.SafeLogger
 /**
  * Maps exceptions from the application to either fatal or non fatal exceptions
  * based on whether we think retrying them has a chance of succeeding
  * see support-workers/docs/error-handling.md
  */
-object ErrorHandler extends LazyLogging {
+object ErrorHandler {
   val handleException: PartialFunction[Throwable, Any] = {
     //Stripe
     case e: Stripe.StripeError => logAndRethrow(e.asRetryException)
@@ -33,7 +33,7 @@ object ErrorHandler extends LazyLogging {
   }
 
   def logAndRethrow(t: RetryException): Unit = {
-    logger.error(s"${t.getMessage}", t)
+    SafeLogger.error(scrub"${t.getMessage}", t)
     throw t
   }
 }

--- a/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/SerialisationSpec.scala
@@ -5,13 +5,13 @@ import com.gu.support.workers.model.PaymentFields
 import com.gu.zuora.Fixtures._
 import com.gu.zuora.encoding.CustomCodecs._
 import com.gu.zuora.model.response._
-import com.typesafe.scalalogging.LazyLogging
 import io.circe
 import io.circe.parser._
 import io.circe.syntax._
 import org.scalatest.{FlatSpec, Matchers}
+import com.gu.monitoring.SafeLogger
 
-class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
+class SerialisationSpec extends FlatSpec with Matchers {
 
   "Account" should "serialise to correct json" in {
     val json = account(GBP).asJson
@@ -67,8 +67,8 @@ class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
     //but actually it returns a list of those.
     val decodeResult = decode[List[ZuoraErrorResponse]](Fixtures.errorResponse)
     decodeResult match {
-      case r: Right[circe.Error, List[ZuoraErrorResponse]] => logger.info("right")
-      case l: Left[circe.Error, List[ZuoraErrorResponse]] => logger.info("left")
+      case r: Right[circe.Error, List[ZuoraErrorResponse]] => SafeLogger.info("right")
+      case l: Left[circe.Error, List[ZuoraErrorResponse]] => SafeLogger.info("left")
     }
     decodeResult.isRight should be(true)
     decodeResult.right.get.head.errors.size should be(1)

--- a/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/common/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -2,19 +2,20 @@ package com.gu.zuora
 
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.gu.okhttp.RequestRunners
 import com.gu.support.workers.model.Monthly
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
 import com.gu.zuora.model.SubscribeRequest
 import com.gu.zuora.model.response.ZuoraErrorResponse
-import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
 @IntegrationTest
-class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
+class ZuoraSpec extends AsyncFlatSpec with Matchers {
 
   def uatService: ZuoraService = new ZuoraService(zuoraConfigProvider.get(true), RequestRunners.configurableFutureRunner(30.seconds))
 
@@ -127,7 +128,7 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers with LazyLogging {
       response =>
         response.head.success should be(true)
     }.recover {
-      case e: ZuoraErrorResponse => logger.error(s"Zuora error: $e", e); fail()
+      case e: ZuoraErrorResponse => SafeLogger.error(scrub"Zuora error: $e", e); fail()
     }
   }
 }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/ContributionCompleted.scala
@@ -1,15 +1,14 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.monthlyContributions.Status
 import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, SendThankYouEmailState}
 import com.gu.support.workers.model.{ExecutionError, RequestInfo}
-import com.typesafe.scalalogging.LazyLogging
 
 class ContributionCompleted
-    extends Handler[SendThankYouEmailState, CompletedState]
-    with LazyLogging {
+    extends Handler[SendThankYouEmailState, CompletedState] {
 
   override protected def handler(state: SendThankYouEmailState, error: Option[ExecutionError], requestInfo: RequestInfo, context: Context) = {
     val fields = List(
@@ -19,7 +18,7 @@ class ContributionCompleted
       "payment_method" -> state.paymentMethod.`type`
     )
 
-    logger.info(fields.map({ case (k, v) => s"$k: $v" }).mkString("SUCCESS ", " ", ""))
+    SafeLogger.info(fields.map({ case (k, v) => s"$k: $v" }).mkString("SUCCESS ", " ", ""))
 
     HandlerResult(CompletedState(
       requestId = state.requestId,

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -3,7 +3,6 @@ package com.gu.support.workers.lambdas
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
 import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.paypal.PayPalService
 import com.gu.services.{ServiceProvider, Services}
@@ -23,6 +22,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
+    SafeLogger.debug(s"CreatePaymentMethod state: $state")
     for {
       paymentMethod <- createPaymentMethod(state, services)
       _ <- putCloudWatchMetrics(paymentMethod.toFriendlyString)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -11,17 +11,21 @@ import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.lambdas.PaymentMethodExtensions.PaymentMethodExtension
 import com.gu.support.workers.model._
 import com.gu.support.workers.model.monthlyContributions.state.{CreatePaymentMethodState, CreateSalesforceContactState}
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[CreatePaymentMethodState, CreateSalesforceContactState](servicesProvider) {
+    extends ServicesHandler[CreatePaymentMethodState, CreateSalesforceContactState](servicesProvider) with LazyLogging {
 
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
     SafeLogger.debug(s"CreatePaymentMethod state: $state")
+    SafeLogger.info(s"CreatePaymentMethod state: $state")
+    val someTestVariable = "Happy Tuesday, pal!"
+    logger.error(s"JUST A TEST. Leigh-Anne is learning how to scrub logs sent to sentry. Here is a message-in-a-variable: $someTestVariable")
 
     for {
       paymentMethod <- createPaymentMethod(state, services)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -25,8 +25,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
     SafeLogger.debug(s"CreatePaymentMethod state: $state")
     SafeLogger.info(s"CreatePaymentMethod state: $state")
-    val someTestVariable = "Happy Tuesday, pal!"
-    SafeLogger.error(scrub"JUST A TEST. Leigh-Anne is learning how to scrub logs sent to sentry. Here is a message-in-a-variable: $someTestVariable")
+    val someTestVariable = "<Why, you look utterly radiant on this sunny Tuesday!>"
+    SafeLogger.error(scrub"IGNORE ME. Leigh-Anne is learning how to scrub logs sent to sentry. Look at this variable I've logged: $someTestVariable")
 
     for {
       paymentMethod <- createPaymentMethod(state, services)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers.lambdas
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.paypal.PayPalService
 import com.gu.services.{ServiceProvider, Services}
@@ -25,7 +26,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     SafeLogger.debug(s"CreatePaymentMethod state: $state")
     SafeLogger.info(s"CreatePaymentMethod state: $state")
     val someTestVariable = "Happy Tuesday, pal!"
-    logger.error(s"JUST A TEST. Leigh-Anne is learning how to scrub logs sent to sentry. Here is a message-in-a-variable: $someTestVariable")
+    SafeLogger.error(scrub"JUST A TEST. Leigh-Anne is learning how to scrub logs sent to sentry. Here is a message-in-a-variable: $someTestVariable")
 
     for {
       paymentMethod <- createPaymentMethod(state, services)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -23,11 +23,6 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
-    SafeLogger.debug(s"CreatePaymentMethod state: $state")
-    SafeLogger.info(s"CreatePaymentMethod state: $state")
-    val someTestVariable = "<Why, you look utterly radiant on this sunny Tuesday!>"
-    SafeLogger.error(scrub"IGNORE ME. Leigh-Anne is learning how to scrub logs sent to sentry. Look at this variable I've logged: $someTestVariable")
-
     for {
       paymentMethod <- createPaymentMethod(state, services)
       _ <- putCloudWatchMetrics(paymentMethod.toFriendlyString)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -23,9 +23,6 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
-    val someTestVariable = "Happy Tuesday, pal!"
-    SafeLogger.error(scrub"IGNORE ME. Leigh-Anne is learning how to scrub logs sent to sentry. Look at this variable I've logged: $someTestVariable")
-
     for {
       paymentMethod <- createPaymentMethod(state, services)
       _ <- putCloudWatchMetrics(paymentMethod.toFriendlyString)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.i18n.{CountryGroup, Currency}
+import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.paypal.PayPalService
 import com.gu.services.{ServiceProvider, Services}
@@ -10,18 +11,17 @@ import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.lambdas.PaymentMethodExtensions.PaymentMethodExtension
 import com.gu.support.workers.model._
 import com.gu.support.workers.model.monthlyContributions.state.{CreatePaymentMethodState, CreateSalesforceContactState}
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[CreatePaymentMethodState, CreateSalesforceContactState](servicesProvider) with LazyLogging {
+    extends ServicesHandler[CreatePaymentMethodState, CreateSalesforceContactState](servicesProvider) {
 
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
-    logger.debug(s"CreatePaymentMethod state: $state")
+    SafeLogger.debug(s"CreatePaymentMethod state: $state")
 
     for {
       paymentMethod <- createPaymentMethod(state, services)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -23,6 +23,9 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(state: CreatePaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
+    val someTestVariable = "Happy Tuesday, pal!"
+    SafeLogger.error(scrub"IGNORE ME. Leigh-Anne is learning how to scrub logs sent to sentry. Look at this variable I've logged: $someTestVariable")
+
     for {
       paymentMethod <- createPaymentMethod(state, services)
       _ <- putCloudWatchMetrics(paymentMethod.toFriendlyString)

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -1,20 +1,20 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.monitoring.SafeLogger
 import com.gu.salesforce.Salesforce.{SalesforceContactResponse, UpsertData}
 import com.gu.services.Services
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.exceptions.SalesforceException
 import com.gu.support.workers.model.RequestInfo
 import com.gu.support.workers.model.monthlyContributions.state.{CreateSalesforceContactState, CreateZuoraSubscriptionState}
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactState, CreateZuoraSubscriptionState] with LazyLogging {
+class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactState, CreateZuoraSubscriptionState] {
 
   override protected def servicesHandler(state: CreateSalesforceContactState, requestInfo: RequestInfo, context: Context, services: Services) = {
-    logger.debug(s"CreateSalesforceContact state: $state")
+    SafeLogger.debug(s"CreateSalesforceContact state: $state")
     services.salesforceService.upsert(UpsertData.create(
       state.user.id,
       state.user.primaryEmailAddress,
@@ -30,7 +30,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
         HandlerResult(getCreateZuoraSubscriptionState(state, response), requestInfo)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
-        logger.warn(s"Error creating Salesforce contact:\n$errorMessage")
+        SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
         throw new SalesforceException(errorMessage)
       })
   }

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration.zuoraConfigProvider
+import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.products.RecurringContributionsMetrics
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.encoding.StateCodecs._
@@ -9,15 +10,13 @@ import com.gu.support.workers.model.RequestInfo
 import com.gu.support.workers.model.monthlyContributions.state.{CreateZuoraSubscriptionState, SendThankYouEmailState}
 import com.gu.zuora.model._
 import com.gu.zuora.model.response.{Subscription => SubscriptionResponse}
-import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.{DateTimeZone, LocalDate}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider)
-    with LazyLogging {
+    extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider) {
 
   def this() = this(ServiceProvider)
 
@@ -34,7 +33,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
 
   def skipSubscribe(state: CreateZuoraSubscriptionState, requestInfo: RequestInfo, subscription: SubscriptionResponse): FutureHandlerResult = {
     val message = "Skipping subscribe for user because they are already an active contributor"
-    logger.info(message)
+    SafeLogger.info(message)
     FutureHandlerResult(getEmailState(state, subscription.accountNumber), requestInfo.appendMessage(message))
   }
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
+import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.monthlyContributions.state.SendThankYouEmailState
@@ -11,13 +12,12 @@ import com.gu.support.workers.model.{DirectDebitPaymentMethod, RequestInfo}
 import com.gu.threadpools.CustomPool.executionContext
 import com.gu.zuora.ZuoraService
 import com.gu.zuora.encoding.CustomCodecs._
-import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
 
 import scala.concurrent.Future
 
 class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[SendThankYouEmailState, Unit](servicesProvider) with LazyLogging {
+    extends ServicesHandler[SendThankYouEmailState, Unit](servicesProvider) {
 
   def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, executionContext))
 
@@ -27,7 +27,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
     context: Context,
     services: Services
   ): FutureHandlerResult = {
-    logger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
+    SafeLogger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
     for {
       mandateId <- fetchDirectDebitMandateId(state, services.zuoraService)
       emailResult <- sendEmail(state, mandateId)

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -4,14 +4,15 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.{EUR, GBP}
+import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.Fixtures.{createPayPalPaymentMethodJson, wrapFixture}
 import com.gu.support.workers.lambdas._
 import com.gu.support.workers.model.JsonWrapper
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.encoding.CustomCodecs.{jsonWrapperDecoder, jsonWrapperEncoder}
 import io.circe.parser._
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.io.Source
 
 @IntegrationTest
@@ -22,7 +23,7 @@ class EndToEndSpec extends LambdaSpec {
   they should "work with other currencies" in runSignupWithCurrency(EUR)
 
   def runSignupWithCurrency(currency: Currency) {
-    logger.info(createPayPalPaymentMethodJson(currency))
+    SafeLogger.info(createPayPalPaymentMethodJson(currency))
     val output = wrapFixture(createPayPalPaymentMethodJson())
       .chain(new CreatePaymentMethod())
       .chain(new CreateSalesforceContact())

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -5,16 +5,15 @@ import java.io.ByteArrayOutputStream
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
-import com.typesafe.scalalogging.LazyLogging
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Assertion, AsyncFlatSpec, FlatSpec, Matchers}
 
-abstract class LambdaSpec extends FlatSpec with Matchers with MockContext with LazyLogging {
+abstract class LambdaSpec extends FlatSpec with Matchers with MockContext {
   def assertUnit(output: ByteArrayOutputStream): Assertion =
     Encoding.in[Unit](output.toInputStream).isSuccess should be(true)
 }
-abstract class AsyncLambdaSpec extends AsyncFlatSpec with Matchers with LazyLogging {
+abstract class AsyncLambdaSpec extends AsyncFlatSpec with Matchers {
   implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 }
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/WrapperSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.support.workers
 
+import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.Fixtures.{contribution, wrapFixture}
 import com.gu.support.workers.encoding.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Encoding
@@ -7,10 +8,9 @@ import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.monthlyContributions.state.CreateSalesforceContactState
 import com.gu.zuora.encoding.CustomCodecs._
-import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FlatSpec, Matchers}
 
-class WrapperSpec extends FlatSpec with Matchers with LazyLogging {
+class WrapperSpec extends FlatSpec with Matchers {
   "JsonWrapper" should "be able to round trip some json" in {
     val wrapped = wrapFixture(contribution())
 
@@ -19,7 +19,7 @@ class WrapperSpec extends FlatSpec with Matchers with LazyLogging {
   }
   it should "be able to handle a JsonWrapper with messages" in {
     val result = Encoding.in[CreateSalesforceContactState](Fixtures.wrapperWithMessages.asInputStream)
-    logger.info(s"$result")
+    SafeLogger.info(s"$result")
     result.isSuccess should be(true)
   }
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -1,25 +1,25 @@
 package com.gu.support.workers.errors
 
 import com.gu.config.Configuration
+import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.salesforce.Fixtures._
 import com.gu.salesforce.Salesforce.{Authentication, SalesforceAuthenticationErrorResponse, SalesforceErrorResponse, UpsertData}
 import com.gu.salesforce.{AuthService, SalesforceConfig, SalesforceService}
 import com.gu.support.workers.AsyncLambdaSpec
 import com.gu.test.tags.annotations.IntegrationTest
-import com.typesafe.scalalogging.LazyLogging
 import okhttp3.Request
 import org.scalatest.Matchers
 
 import scala.concurrent.duration._
 
 @IntegrationTest
-class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers with LazyLogging {
+class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
   "AuthService" should "throw a SalesforceAuthenticationErrorResponse" in {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
     val authService = new AuthService(invalidConfig)
     recoverToSucceededIf[SalesforceAuthenticationErrorResponse] {
-      authService.authorize.map(auth => logger.info(s"Got an auth: $auth"))
+      authService.authorize.map(auth => SafeLogger.info(s"Got an auth: $auth"))
     }
   }
 
@@ -29,7 +29,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers with LazyLoggin
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     assertThrows[SalesforceAuthenticationErrorResponse] {
-      service.upsert(upsertData).map(response => logger.info(s"Got a response: $response"))
+      service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))
     }
   }
 
@@ -42,7 +42,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers with LazyLoggin
     val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail)
 
     recoverToSucceededIf[SalesforceErrorResponse] {
-      service.upsert(upsertData).map(response => logger.info(s"Got a response: $response"))
+      service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))
     }
   }
 

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream
 
 import cats.syntax.either._
 import com.gu.config.Configuration
+import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
 import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrapFixture}
@@ -17,7 +18,6 @@ import com.gu.zuora.Fixtures.{incorrectPaymentMethod, invalidSubscriptionRequest
 import com.gu.zuora.ZuoraService
 import com.gu.zuora.encoding.CustomCodecs.jsonWrapperDecoder
 import com.gu.zuora.model.response.ZuoraErrorResponse
-import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser.decode
 import org.scalatest.RecoverMethods
 
@@ -25,13 +25,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 @IntegrationTest
-class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServicesCreator with RecoverMethods with LazyLogging {
+class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServicesCreator with RecoverMethods {
   "Subscribe request with invalid term type" should "fail with a ZuoraErrorResponse" in {
     val zuoraService = new ZuoraService(Configuration.zuoraConfigProvider.get(), configurableFutureRunner(30.seconds))
     recoverToSucceededIf[ZuoraErrorResponse] {
       zuoraService.subscribe(invalidSubscriptionRequest).map {
         response =>
-          logger.info(s"response: $response")
+          SafeLogger.info(s"response: $response")
       }
     }
   }
@@ -41,7 +41,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     recoverToSucceededIf[ZuoraErrorResponse] {
       zuoraService.subscribe(incorrectPaymentMethod).map {
         response =>
-          logger.info(s"response: $response")
+          SafeLogger.info(s"response: $response")
       }
     }
   }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
 import com.gu.i18n.Currency
+import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.Fixtures.{cardDeclinedJsonStripe, cardDeclinedJsonZuora, failureJson}
 import com.gu.support.workers.encoding.Conversions.{FromOutputStream, StringInputStreamConversions}
 import com.gu.support.workers.encoding.Encoding
@@ -53,7 +54,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     val outState = decode[JsonWrapper](Source.fromInputStream(outStream.toInputStream).mkString)
     outState.right.get.requestInfo.failed should be(false)
-    logger.info(outState.right.get.requestInfo.messages.head)
+    SafeLogger.info(outState.right.get.requestInfo.messages.head)
   }
 
   it should "return a non failed JsonWrapper for Stripe payment errors" in {
@@ -65,7 +66,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     val outState = decode[JsonWrapper](Source.fromInputStream(outStream.toInputStream).mkString)
     outState.right.get.requestInfo.failed should be(false)
-    logger.info(outState.right.get.requestInfo.messages.head)
+    SafeLogger.info(outState.right.get.requestInfo.messages.head)
   }
 
   it should "return a Status.Failure for a Zuora card declined error" in {


### PR DESCRIPTION
## Why are you doing this?
We want to stop sending PII to sentry as we don't typically use it to debug problems at a user level. More justification here: https://github.com/guardian/support-frontend/pull/494

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/kAuozREd/1501-strip-any-pii-from-support-workers-logs-errors-before-sending-them-to-sentry)

## Changes

* Brought in the SafeLogger from https://github.com/guardian/support-frontend/pull/494
* Used SafeLogger everywhere 
* Added an additional log filter, which removes any error messages that have not been scrubbed and applied it to the Sentry appender 


