### PR TITLE
Pass through SF auth errors

### DIFF
--- a/common/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/common/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -82,7 +82,9 @@ object Salesforce {
     implicit val codec: Codec[SalesforceAuthenticationErrorResponse] = deriveCodec
   }
 
-  case class SalesforceAuthenticationErrorResponse(error: String, error_description: String) extends Throwable
+  case class SalesforceAuthenticationErrorResponse(error: String, error_description: String) extends Throwable {
+    override def getMessage: String = s"error: $error + error_description: $error_description"
+  }
 
   object Authentication {
     implicit val codec: Codec[Authentication] = deriveCodec


### PR DESCRIPTION
## Why are you doing this?

To make it easier to debug issues with Salesforce authentication.

## Changes

* Override getMessage for SalesforceAuthenticationErrorResponse so that we get a useful error [here](https://github.com/guardian/support-workers/blob/baa1d6787a819a8100c7e20a4b56fe73d5f3b9c8/common/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala#L21).

