### PR TITLE
Return a value from the SendThankYouEmail lambda

### DIFF
--- a/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
+++ b/common/src/main/scala/com/gu/zuora/encoding/CustomCodecs.scala
@@ -3,6 +3,7 @@ package com.gu.zuora.encoding
 import java.util.UUID
 
 import cats.syntax.functor._
+import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.helpers.StringExtensions._
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.support.workers.encoding.Codec
@@ -93,6 +94,8 @@ trait ModelsCodecs {
     import com.gu.acquisition.instances.abTest._
     deriveCodec
   }
+
+  implicit val sendMessageResultCodec: Codec[SendMessageResult] = deriveCodec
 
 }
 

--- a/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/monthly-contributions/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -17,7 +17,7 @@ import org.joda.time.DateTime
 import scala.concurrent.Future
 
 class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[SendThankYouEmailState, Unit](servicesProvider) {
+    extends ServicesHandler[SendThankYouEmailState, SendMessageResult](servicesProvider) {
 
   def this() = this(new EmailService(Configuration.emailServicesConfig.thankYou, executionContext))
 
@@ -31,7 +31,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
     for {
       mandateId <- fetchDirectDebitMandateId(state, services.zuoraService)
       emailResult <- sendEmail(state, mandateId)
-    } yield HandlerResult(Unit, requestInfo)
+    } yield HandlerResult(emailResult, requestInfo)
   }
 
   def fetchDirectDebitMandateId(state: SendThankYouEmailState, zuoraService: ZuoraService): Future[Option[String]] = state.paymentMethod match {

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -1,18 +1,12 @@
 package com.gu.support.workers
 
-import java.io.ByteArrayOutputStream
-
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.support.workers.encoding.Conversions.FromOutputStream
-import com.gu.support.workers.encoding.Encoding
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{Assertion, AsyncFlatSpec, FlatSpec, Matchers}
+import org.scalatest.{AsyncFlatSpec, FlatSpec, Matchers}
 
-abstract class LambdaSpec extends FlatSpec with Matchers with MockContext {
-  def assertUnit(output: ByteArrayOutputStream): Assertion =
-    Encoding.in[Unit](output.toInputStream).isSuccess should be(true)
-}
+abstract class LambdaSpec extends FlatSpec with Matchers with MockContext
+
 abstract class AsyncLambdaSpec extends AsyncFlatSpec with Matchers {
   implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 }

--- a/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/monthly-contributions/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -2,15 +2,19 @@ package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
 
+import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.config.Configuration
 import com.gu.emailservices.{EmailFields, EmailService}
 import com.gu.i18n.Currency
 import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
+import com.gu.support.workers.encoding.Conversions.FromOutputStream
+import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.support.workers.model.DirectDebitPaymentMethod
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.threadpools.CustomPool.executionContext
+import com.gu.zuora.encoding.CustomCodecs._
 import io.circe.Json
 import io.circe.parser._
 import org.joda.time.DateTime
@@ -25,7 +29,8 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
     sendThankYouEmail.handleRequest(wrapFixture(thankYouEmailJson), outStream, context)
 
-    assertUnit(outStream)
+    val result = Encoding.in[SendMessageResult](outStream.toInputStream)
+    result.isSuccess should be(true)
   }
 
   ignore should "send an email" in {


### PR DESCRIPTION
## Why are you doing this?
We recently had [a bug](https://github.com/guardian/support-workers/pull/116) which resulted from the SendThankYouEmail lambda exiting with an incomplete future pending. 
This partly came about because it returns `Unit` so it was easy to miss that we hadn't completed an operation. By changing the return type to the value that is returned by the future we make any recurrence of this less likely.


