### PR TITLE
Add retries for ContributionCompleted lambda

### DIFF
--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -71,7 +71,6 @@ States:
       detects that the execution is complete.  This could happen during a deployment when a new state machine
       is created and the old is terminated.
     End: True
-    {{> retry}}
 
   FailState:
     Type: Fail

--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -32,6 +32,7 @@ States:
           Type: Task
           Resource: "${ContributionCompletedLambda.Arn}"
           End: True
+          {{> retry}}
     - StartAt: SendThankYouEmail
       States:
         SendThankYouEmail:
@@ -70,6 +71,7 @@ States:
       detects that the execution is complete.  This could happen during a deployment when a new state machine
       is created and the old is terminated.
     End: True
+    {{> retry}}
 
   FailState:
     Type: Fail


### PR DESCRIPTION
## Why are you doing this?

We recently saw a failed execution due to a _Lambda.AWSLambdaException_ being thrown during the ContributionCompleted task. As there were no retries configured for this lambda, this caused the whole state machine execution to fail, and we incorrectly reported a failure to the client (even though the payment had been taken).

## Changes

* Add the default retries block (which includes a [catch all](https://github.com/guardian/support-workers/blob/master/cloud-formation/src/templates/retries.yaml#L15-L19) for this type of exception) to the ContributionCompleted lambda

