### PR TITLE
Config fix

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -30,13 +30,37 @@ touchpoint.backend.environments {
       }
       contribution {
         monthly {
-          productRatePlanId=""
-          productRatePlanChargeId=""
+          productRatePlanId="2c92c0f85a6b134e015a7fcd9f0c7855"
+          productRatePlanChargeId="2c92c0f85a6b1352015a7fcf35ab397c"
         }
         annual {
-          productRatePlanId=""
-          productRatePlanChargeId=""
+          productRatePlanId="2c92c0f85e2d19af015e3896e824092c"
+          productRatePlanChargeId="2c92c0f85e2d19af015e3896e84d092e"
         }
+      }
+    }
+  }
+  UAT {
+    zuora.contribution {
+      monthly {
+        productRatePlanId="2c92c0f85ab269be015acd9d014549b7"
+        productRatePlanChargeId="2c92c0f85ab2696b015acd9eeb6150ab"
+      }
+      annual {
+        productRatePlanId="2c92c0f95e1d5c9c015e38f8c87d19a1"
+        productRatePlanChargeId="2c92c0f95e1d5c9c015e38f8c8ac19a3"
+      }
+    }
+  }
+  PROD {
+    zuora.contribution {
+      monthly {
+        productRatePlanId="2c92a0fc5aacfadd015ad24db4ff5e97"
+        productRatePlanChargeId="2c92a0fc5aacfadd015ad250bf2c6d38"
+      }
+      annual {
+        productRatePlanId="2c92a0fc5e1dc084015e37f58c200eea"
+        productRatePlanChargeId="2c92a0fc5e1dc084015e37f58c7b0f34"
       }
     }
   }

--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -165,12 +165,22 @@ object Fixtures {
         }
       """
 
-  def createZuoraSubscriptionJson(billingPeriod: BillingPeriod = Monthly) =
+  def createContributionZuoraSubscriptionJson(billingPeriod: BillingPeriod = Monthly) =
     s"""
           {
             $requestIdJson,
             $userJson,
             "product": ${contribution(billingPeriod = billingPeriod)},
+            "paymentMethod": $payPalPaymentMethod,
+            "salesForceContact": $salesforceContactJson
+            }
+        """
+  def createDigiPackZuoraSubscriptionJson =
+    s"""
+          {
+            $requestIdJson,
+            $userJson,
+            "product": ${digitalPackJson},
             "paymentMethod": $payPalPaymentMethod,
             "salesForceContact": $salesforceContactJson
             }

--- a/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
+++ b/src/test/scala/com/gu/support/workers/errors/ZuoraErrorsSpec.scala
@@ -6,7 +6,7 @@ import com.gu.config.Configuration
 import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.ServiceProvider
-import com.gu.support.workers.Fixtures.{createZuoraSubscriptionJson, wrapFixture}
+import com.gu.support.workers.Fixtures.{createContributionZuoraSubscriptionJson, wrapFixture}
 import com.gu.support.workers.encoding.ErrorJson
 import com.gu.support.workers.exceptions.RetryUnlimited
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
@@ -49,7 +49,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val createZuoraSubscription = new CreateZuoraSubscription(timeoutServices)
     val outputStream = new ByteArrayOutputStream()
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson()), outputStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createContributionZuoraSubscriptionJson()), outputStream, context)
     }
   }
 
@@ -63,7 +63,7 @@ class ZuoraErrorsSpec extends LambdaSpec with MockWebServerCreator with MockServ
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createZuoraSubscription.handleRequest(wrapFixture(createZuoraSubscriptionJson()), outStream, context)
+      createZuoraSubscription.handleRequest(wrapFixture(createContributionZuoraSubscriptionJson()), outStream, context)
     }
 
     server.shutdown()

--- a/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -7,20 +7,27 @@ import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.errors.MockServicesCreator
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.model.states.SendThankYouEmailState
-import com.gu.support.workers.model.{Annual, Monthly}
+import com.gu.support.workers.model.{Annual, BillingPeriod, Monthly}
 import com.gu.test.tags.annotations.IntegrationTest
+import com.gu.zuora.ZuoraService
+import com.gu.zuora.model.SubscribeRequest
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+
+import scala.concurrent.Future
 
 @IntegrationTest
-class CreateZuoraSubscriptionSpec extends LambdaSpec {
+class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
 
   "CreateZuoraSubscription lambda" should "create a monthly Zuora subscription" in {
     val createZuora = new CreateZuoraSubscription()
 
     val outStream = new ByteArrayOutputStream()
 
-    createZuora.handleRequest(wrapFixture(createZuoraSubscriptionJson(billingPeriod = Monthly)), outStream, context)
+    createZuora.handleRequest(wrapFixture(createContributionZuoraSubscriptionJson(billingPeriod = Monthly)), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
     sendThankYouEmail._1.accountNumber.length should be > 0
@@ -31,9 +38,34 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec {
 
     val outStream = new ByteArrayOutputStream()
 
-    createZuora.handleRequest(wrapFixture(createZuoraSubscriptionJson(billingPeriod = Annual)), outStream, context)
+    createZuora.handleRequest(wrapFixture(createContributionZuoraSubscriptionJson(billingPeriod = Annual)), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
     sendThankYouEmail._1.accountNumber.length should be > 0
   }
+
+  "CreateZuoraSubscription lambda" should "create a Digital Pack subscription" in {
+    val createZuora = new CreateZuoraSubscription(mockServiceProvider)
+
+    val outStream = new ByteArrayOutputStream()
+
+    createZuora.handleRequest(wrapFixture(createDigiPackZuoraSubscriptionJson), outStream, context)
+
+    val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
+    sendThankYouEmail._1.accountNumber.length should be > 0
+  }
+
+  val mockService = {
+    val z = mock[ZuoraService]
+    // Need to return None from the Zuora service `getRecurringSubscription`
+    // method or the subscribe step gets skipped
+    when(z.getRecurringSubscription(any[String], any[BillingPeriod])).thenReturn(Future.successful(None))
+    when(z.subscribe(any[SubscribeRequest])).thenCallRealMethod()
+    z
+  }
+
+  val mockServiceProvider = mockServices(
+    s => s.zuoraService,
+    mockService
+  )
 }


### PR DESCRIPTION
## Why are you doing this?

* I noticed that the private config files currently contain all the Zuora product ids which could be public so I've moved them to the public config to simplify things.
* I also noticed that the `CreateZuoraSubscriptionSpec` tests are not currently testing anything because there is code in ZuoraService to prevent multiple recurring contributions with the same Identity id. To get round this I have mocked the method which checks for a subscription to always return `None`