### PR TITLE
send alerts to simple-dev only

### DIFF
--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -125,7 +125,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub State Machine Failure in ${Stage} (Monthly Contributions Sign-Ups)
       AlarmDescription: The Monthly Contributions state machine failed during execution - please investigate.
       MetricName: ExecutionsFailed
@@ -145,7 +145,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
       AlarmName: !Sub Monthly Contributions Sign-Up Timeout in ${Stage}
       AlarmDescription: An execution of the Monthly Contributions state machine has taken an excessively long time to complete
       MetricName: ExecutionsTimedOut


### PR DESCRIPTION
Currently a state machine failure is broadcast to all of reader revenue dev.
This is overkill as 2/3's of recipients are not going to take any action on the alert.
Moreover this increases the risk of developers "tuning out" AWS alerts as a result of them being frequent and not relevant to their immediate area of responsibility.
The plan going forward is to send alerts that are not time critical to the specific team of responsibility, reserving the reader.revenue.dev email address for time critical "everything is on fire!" style alerts - where we want action to be taken by the first person to see the alert. 
