### PR TITLE
Use pass state as indicator for checkout success

### DIFF
--- a/cloud-formation/src/templates/state-machine.yaml
+++ b/cloud-formation/src/templates/state-machine.yaml
@@ -26,13 +26,11 @@ States:
   ParallelTasks:
     Type: Parallel
     Branches:
-    - StartAt: ContributionCompleted
+    - StartAt: CheckoutSuccess
       States:
-        ContributionCompleted:
-          Type: Task
-          Resource: "${ContributionCompletedLambda.Arn}"
+        CheckoutSuccess: #Do not rename this step as it is used by support-frontend's polling logic.
+          Type: Pass
           End: True
-          {{> retry}}
     - StartAt: SendThankYouEmail
       States:
         SendThankYouEmail:


### PR DESCRIPTION
## Why are you doing this?

Instead of using a lambda, we now use a [Pass State](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-pass-state.html) to indicate success. This means that we don't need to worry about schema changes in the future (more details on why this is bad here: https://github.com/guardian/support-frontend/pull/811). 

This change should also speed up executions / in-browser feedback as users will never have to wait for a superfluous lambda to run (or cold start).

It also allows us to remove the ContributionCompleted lambda function - as far as I can tell this just logs and produces JSON output to indicate success. I'll do that in a separate PR for the reasons detailed here: https://github.com/guardian/support-workers#deployment

## Changes

* Use a pass state instead of a lambda to signify that a contribution has completed.

