### PR TITLE
Send identity id through in acquisition event

### DIFF
--- a/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -83,7 +83,8 @@ object SendAcquisitionEvent {
               componentTypeV2 = data.referrerAcquisitionData.componentType,
               source = data.referrerAcquisitionData.source,
               platform = Some(ophan.thrift.event.Platform.Support),
-              queryParameters = data.referrerAcquisitionData.queryParameters
+              queryParameters = data.referrerAcquisitionData.queryParameters,
+              identityId = Some(state.user.id)
             )
           },
           "acquisition data not included"


### PR DESCRIPTION
## Why are you doing this?

Previously, when running the `acquisitions` job in the excavator, we relied on joining on the `pageview` table to get the `identity id` for recurring contributions. Seeing as it is available here, we should send it through, lessening our dependence on the `pageview` table.

@guardian/contributions 