### PR TITLE
set product in email fields

### DIFF
--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -11,6 +11,7 @@ case class ContributionEmailFields(
     currency: Currency,
     edition: String,
     name: String,
+    product: String,
     paymentMethod: Option[PaymentMethod] = None,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
@@ -34,7 +35,7 @@ case class ContributionEmailFields(
     "currency" -> currency.glyph,
     "edition" -> edition,
     "name" -> name,
-    "product" -> "monthly-contribution"
+    "product" -> product
   ) ++ paymentFields
 
   override def payload: String = super.payload(email, "regular-contribution-thank-you")

--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -1,7 +1,7 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency
-import com.gu.support.workers.model.{DirectDebitPaymentMethod, PaymentMethod}
+import com.gu.support.workers.model.{BillingPeriod, DirectDebitPaymentMethod, PaymentMethod}
 import org.joda.time.DateTime
 
 case class ContributionEmailFields(
@@ -11,7 +11,7 @@ case class ContributionEmailFields(
     currency: Currency,
     edition: String,
     name: String,
-    product: String,
+    billingPeriod: BillingPeriod,
     paymentMethod: Option[PaymentMethod] = None,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
@@ -35,7 +35,7 @@ case class ContributionEmailFields(
     "currency" -> currency.glyph,
     "edition" -> edition,
     "name" -> name,
-    "product" -> product
+    "product" -> s"${billingPeriod.toString.toLowerCase}-contribution"
   ) ++ paymentFields
 
   override def payload: String = super.payload(email, "regular-contribution-thank-you")

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -49,6 +49,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           currency = c.currency,
           edition = state.user.country.alpha2,
           name = state.user.firstName,
+          product = s"${state.product.billingPeriod}-contribution",
           paymentMethod = Some(state.paymentMethod),
           directDebitMandateId = directDebitMandateId
         )

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -49,7 +49,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           currency = c.currency,
           edition = state.user.country.alpha2,
           name = state.user.firstName,
-          product = s"${state.product.billingPeriod}-contribution",
+          billingPeriod = state.product.billingPeriod,
           paymentMethod = Some(state.paymentMethod),
           directDebitMandateId = directDebitMandateId
         )

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -44,7 +44,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", "", Some(dd), Some(mandateId)
+      "UK", "", Monthly, Some(dd), Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -71,7 +71,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   "EmailFields" should "include Direct Debit fields in the payload" in {
     val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
     val mandateId = "65HK26E"
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", "", Some(dd), Some(mandateId))
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, Some(dd), Some(mandateId))
     val resultJson = parse(ef.payload)
 
     resultJson.isRight should be(true)
@@ -87,7 +87,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   }
 
   it should "still work without a Payment Method" in {
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", "")
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly)
     val resultJson = parse(ef.payload)
     resultJson.isRight should be(true)
     (resultJson.right.get \\ "payment method").isEmpty should be(true)

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -44,7 +44,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Some(dd), Some(mandateId)
+      "UK", "", "", Some(dd), Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -71,7 +71,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   "EmailFields" should "include Direct Debit fields in the payload" in {
     val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
     val mandateId = "65HK26E"
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Some(dd), Some(mandateId))
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", "", Some(dd), Some(mandateId))
     val resultJson = parse(ef.payload)
 
     resultJson.isRight should be(true)
@@ -87,7 +87,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   }
 
   it should "still work without a Payment Method" in {
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "")
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", "")
     val resultJson = parse(ef.payload)
     resultJson.isRight should be(true)
     (resultJson.right.get \\ "payment method").isEmpty should be(true)


### PR DESCRIPTION
## Why are you doing this?
So exact target can send thank you emails tailored to frequency i.e. annual and monthly contributions. 📨

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/6qGb9bHv/751-validate-monthly-and-annual-email-confirmations)


## Changes

* Adds product field to ContributionEmailFields class
* Sets value using `state.product.billingPeriod` which will result in: `Monthly-contribution` or `Annual-contribution`being passed through. 
* Updates test objects to include product field. 

### TODO

- [ ] Use this [test](https://github.com/guardian/support-workers/blob/master/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala#L37) once exact target has been updated to send different templates according to the product value, to ensure correct emails are sent. 

