### PR TITLE
Add sfContactId to Email payload

### DIFF
--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -3,6 +3,7 @@ package com.gu.emailservices
 import com.gu.i18n.Currency
 import com.gu.support.workers.model.{BillingPeriod, DirectDebitPaymentMethod, PaymentMethod}
 import org.joda.time.DateTime
+import com.gu.salesforce.Salesforce.SfContactId
 
 case class ContributionEmailFields(
     email: String,
@@ -12,8 +13,7 @@ case class ContributionEmailFields(
     edition: String,
     name: String,
     billingPeriod: BillingPeriod,
-    sfContactId: Option[String],
-    identityId: Option[String],
+    sfContactId: SfContactId,
     paymentMethod: Option[PaymentMethod] = None,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
@@ -41,4 +41,6 @@ case class ContributionEmailFields(
   ) ++ paymentFields
 
   override def payload: String = super.payload(email, "regular-contribution-thank-you")
+
+  override def userId: Either[SfContactId, IdentityUserId] = Left(sfContactId)
 }

--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -12,6 +12,8 @@ case class ContributionEmailFields(
     edition: String,
     name: String,
     billingPeriod: BillingPeriod,
+    sfContactId: Option[String],
+    identityId: Option[String],
     paymentMethod: Option[PaymentMethod] = None,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {

--- a/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -1,6 +1,7 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.workers.model._
 import org.joda.time.DateTime
 
@@ -41,8 +42,7 @@ case class DigitalPackEmailFields(
     user: User,
     currency: Currency,
     paymentMethod: PaymentMethod,
-    sfContactId: Option[String],
-    identityId: Option[String],
+    sfContactId: SfContactId,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
 
@@ -80,4 +80,5 @@ case class DigitalPackEmailFields(
   ) ++ paymentFields //TODO: ++ promotionFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, "digipack")
+  override def userId: Either[SfContactId, IdentityUserId] = Left(sfContactId)
 }

--- a/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -41,6 +41,8 @@ case class DigitalPackEmailFields(
     user: User,
     currency: Currency,
     paymentMethod: PaymentMethod,
+    sfContactId: Option[String],
+    identityId: Option[String],
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
 

--- a/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -6,11 +6,13 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 import com.gu.salesforce.Salesforce.SfContactId
 
+// scalastyle:off
 case class EmailPayloadContactAttributes(SubscriberAttributes: Map[String, String])
 case class EmailPayloadTo(Address: String, SubscriberKey: String, ContactAttributes: EmailPayloadContactAttributes)
 case class EmailPayload(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String]) {
   lazy val jsonString: String = this.asJson.toString
 }
+// scalastyle:on
 
 case class IdentityUserId(id: String)
 

--- a/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -1,35 +1,39 @@
 package com.gu.emailservices
 
-import io.circe.{Json, Printer}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+case class EmailPayloadContactAttributes(SubscriberAttributes: Map[String, String])
+case class EmailPayloadTo(Address: String, SubscriberKey: String, ContactAttributes: EmailPayloadContactAttributes)
+case class EmailPayload(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String]) {
+  lazy val jsonString: String = this.asJson.toString
+}
 
 trait EmailFields {
 
   val fields: List[(String, String)] = Nil
 
   def payload: String
+  def sfContactId: Option[String]
+  def identityId: Option[String]
 
-  protected def payload(email: String, dataExtensionName: String): String =
-    s"""
-       |{
-       |  "To": {
-       |    "Address": "$email",
-       |    "SubscriberKey": "$email",
-       |    "ContactAttributes": {
-       |      "SubscriberAttributes": $fieldsAsJson
-       |    }
-       |  },
-       |  "DataExtensionName": "$dataExtensionName"
-       |}
-    """.stripMargin
-
-  protected def fieldsAsJson = Json
-    .fromFields(fields.map { case (k: String, v: String) => (k, Json.fromString(v)) })
-    .pretty(Printer.spaces2)
+  protected def payload(email: String, dataExtensionName: String): String = {
+    EmailPayload(
+      To = EmailPayloadTo(
+        Address = email,
+        SubscriberKey = email,
+        ContactAttributes = EmailPayloadContactAttributes(SubscriberAttributes = fields.toMap)
+      ),
+      DataExtensionName = dataExtensionName,
+      SfContactId = sfContactId,
+      IdentityUserId = identityId
+    ).jsonString
+  }
 
   protected def mask(s: String): String = s.replace(s.substring(0, 6), "******")
   protected def hyphenate(s: String): String = s"${s.substring(0, 2)}-${s.substring(2, 4)}-${s.substring(4, 6)}"
   protected def formatPrice(price: BigDecimal): String = price.bigDecimal.stripTrailingZeros.toPlainString
-  protected def formatDate(d: DateTime) = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
+  protected def formatDate(d: DateTime): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
 }

--- a/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
@@ -1,5 +1,5 @@
 package com.gu.emailservices
 
-case class FailedContributionEmailFields(email: String) extends EmailFields {
+case class FailedContributionEmailFields(email: String, sfContactId: Option[String], identityId: Option[String]) extends EmailFields {
   override def payload: String = super.payload(email, "contribution-failed")
 }

--- a/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
@@ -1,5 +1,8 @@
 package com.gu.emailservices
 
-case class FailedContributionEmailFields(email: String, sfContactId: Option[String], identityId: Option[String]) extends EmailFields {
+import com.gu.salesforce.Salesforce.SfContactId
+
+case class FailedContributionEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
   override def payload: String = super.payload(email, "contribution-failed")
+  override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
 }

--- a/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
@@ -1,5 +1,8 @@
 package com.gu.emailservices
 
-case class FailedDigitalPackEmailFields(email: String, sfContactId: Option[String], identityId: Option[String]) extends EmailFields {
+import com.gu.salesforce.Salesforce.SfContactId
+
+case class FailedDigitalPackEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
+  override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
   override def payload: String = super.payload(email, "digipack-failed")
 }

--- a/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
@@ -1,5 +1,5 @@
 package com.gu.emailservices
 
-case class FailedDigitalPackEmailFields(email: String) extends EmailFields {
+case class FailedDigitalPackEmailFields(email: String, sfContactId: Option[String], identityId: Option[String]) extends EmailFields {
   override def payload: String = super.payload(email, "digipack-failed")
 }

--- a/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -96,4 +96,6 @@ object Salesforce {
     def isFresh: Boolean = issued_at.isAfter(DateTime.now().minusMinutes(expiryTimeMinutes))
   }
 
+  case class SfContactId(id: String)
+
 }

--- a/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -36,8 +36,8 @@ class FailureHandler(emailService: EmailService) extends FutureHandler[FailureHa
 
   private def sendEmail(state: FailureHandlerState) = {
     val emailFields = state.product match {
-      case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress)
-      case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress)
+      case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress, None, Some(state.user.id))
+      case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, None, Some(state.user.id))
     }
     SafeLogger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)

--- a/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -1,7 +1,7 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields}
+import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields, IdentityUserId}
 import com.gu.helpers.FutureExtensions._
 import com.gu.monitoring.SafeLogger
 import com.gu.stripe.Stripe.StripeError
@@ -9,7 +9,7 @@ import com.gu.support.workers.encoding.ErrorJson
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.CheckoutFailureReasons._
 import com.gu.support.workers.model.states.{CheckoutFailureState, FailureHandlerState}
-import com.gu.support.workers.model.{ExecutionError, RequestInfo, Contribution, DigitalPack}
+import com.gu.support.workers.model.{Contribution, DigitalPack, ExecutionError, RequestInfo}
 import com.gu.zuora.model.response.{ZuoraError, ZuoraErrorResponse}
 import io.circe.Decoder
 import io.circe.parser.decode
@@ -36,8 +36,8 @@ class FailureHandler(emailService: EmailService) extends FutureHandler[FailureHa
 
   private def sendEmail(state: FailureHandlerState) = {
     val emailFields = state.product match {
-      case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress, None, Some(state.user.id))
-      case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, None, Some(state.user.id))
+      case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+      case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     SafeLogger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -50,6 +50,8 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           edition = state.user.country.alpha2,
           name = state.user.firstName,
           billingPeriod = state.product.billingPeriod,
+          sfContactId = Some(state.salesForceContact.Id),
+          identityId = None,
           paymentMethod = Some(state.paymentMethod),
           directDebitMandateId = directDebitMandateId
         )
@@ -59,7 +61,9 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           user = state.user,
           currency = d.currency,
           paymentMethod = state.paymentMethod,
-          directDebitMandateId = directDebitMandateId
+          directDebitMandateId = directDebitMandateId,
+          sfContactId = Some(state.salesForceContact.Id),
+          identityId = None
         )
       }
     )

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.emailservices.{ContributionEmailFields, DigitalPackEmailFields, EmailService}
 import com.gu.monitoring.SafeLogger
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.encoding.StateCodecs._
 import com.gu.support.workers.model.states.SendThankYouEmailState
@@ -50,8 +51,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           edition = state.user.country.alpha2,
           name = state.user.firstName,
           billingPeriod = state.product.billingPeriod,
-          sfContactId = Some(state.salesForceContact.Id),
-          identityId = None,
+          sfContactId = SfContactId(state.salesForceContact.Id),
           paymentMethod = Some(state.paymentMethod),
           directDebitMandateId = directDebitMandateId
         )
@@ -62,8 +62,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           currency = d.currency,
           paymentMethod = state.paymentMethod,
           directDebitMandateId = directDebitMandateId,
-          sfContactId = Some(state.salesForceContact.Id),
-          identityId = None
+          sfContactId = SfContactId(state.salesForceContact.Id)
         )
       }
     )

--- a/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -25,17 +25,17 @@ class EmailFieldsSpec extends FlatSpec with Matchers {
 
     val Right(serializedJson) = parse(
       EmailPayload(
-        EmailPayloadTo(
-          "email@email.com",
-          "email@email.com",
-          EmailPayloadContactAttributes(
-            Map("attribute1" -> "value1", "attribute2" -> "value2")
-          )
-        ),
-        "dataExtensionName",
-        Some("sfContactId"),
-        Some("identityUserId")
-      ).jsonString
+      EmailPayloadTo(
+        "email@email.com",
+        "email@email.com",
+        EmailPayloadContactAttributes(
+          Map("attribute1" -> "value1", "attribute2" -> "value2")
+        )
+      ),
+      "dataExtensionName",
+      Some("sfContactId"),
+      Some("identityUserId")
+    ).jsonString
     )
 
     serializedJson shouldBe expectedJson

--- a/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,0 +1,43 @@
+package com.gu.emailservices
+
+import io.circe._
+import io.circe.parser._
+import org.scalatest.{FlatSpec, Matchers}
+
+class EmailFieldsSpec extends FlatSpec with Matchers {
+  "EmailPayload" should "serialize to json" in {
+    val Right(expectedJson) = parse(
+      s"""
+         |{
+         |  "To": {
+         |    "Address": "email@email.com",
+         |    "SubscriberKey": "email@email.com",
+         |    "ContactAttributes": {
+         |      "SubscriberAttributes": { "attribute1" : "value1" ,  "attribute2" : "value2" }
+         |    }
+         |  },
+         |  "DataExtensionName": "dataExtensionName",
+         |  "SfContactId": "sfContactId",
+         |  "IdentityUserId": "identityUserId"
+         |}
+      """.stripMargin
+    )
+
+    val Right(serializedJson) = parse(
+      EmailPayload(
+        EmailPayloadTo(
+          "email@email.com",
+          "email@email.com",
+          EmailPayloadContactAttributes(
+            Map("attribute1" -> "value1", "attribute2" -> "value2")
+          )
+        ),
+        "dataExtensionName",
+        Some("sfContactId"),
+        Some("identityUserId")
+      ).jsonString
+    )
+
+    serializedJson shouldBe expectedJson
+  }
+}

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -7,6 +7,7 @@ import com.gu.emailservices.{ContributionEmailFields, DigitalPackEmailFields, Em
 import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers.LambdaSpec
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
@@ -44,7 +45,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Monthly, Some("sfContactId"), Some("identityId"), Some(dd), Some(mandateId)
+      "UK", "", Monthly, SfContactId("sfContactId"), Some(dd), Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -62,8 +63,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       user,
       GBP,
       dd,
-      Some("sfContactId"),
-      Some("identityId"),
+      SfContactId("sfContactId"),
       Some(mandateId)
     )
     val service = new EmailService
@@ -73,7 +73,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   "EmailFields" should "include Direct Debit fields in the payload" in {
     val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
     val mandateId = "65HK26E"
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, Some("sfContactId"), Some("identityId"), Some(dd), Some(mandateId))
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, SfContactId("sfContactId"), Some(dd), Some(mandateId))
     val resultJson = parse(ef.payload)
 
     resultJson.isRight should be(true)
@@ -87,11 +87,10 @@ class SendThankYouEmailSpec extends LambdaSpec {
       .validate("payment method", "Direct Debit")
       .validate("currency", "£")
       .validate("SfContactId", "sfContactId")
-      .validate("IdentityUserId", "identityId")
   }
 
   it should "still work without a Payment Method" in {
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly, Some("sfContactId"), Some("identityId"))
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly, SfContactId("sfContactId"))
     val resultJson = parse(ef.payload)
     resultJson.isRight should be(true)
     (resultJson.right.get \\ "payment method").isEmpty should be(true)

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -73,7 +73,18 @@ class SendThankYouEmailSpec extends LambdaSpec {
   "EmailFields" should "include Direct Debit fields in the payload" in {
     val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
     val mandateId = "65HK26E"
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, SfContactId("sfContactId"), Some(dd), Some(mandateId))
+    val ef = ContributionEmailFields(
+      "",
+      new DateTime(1999, 12, 31, 11, 59),
+      20,
+      Currency.GBP,
+      "UK",
+      "",
+      Monthly,
+      SfContactId("sfContactId"),
+      Some(dd),
+      Some(mandateId)
+    )
     val resultJson = parse(ef.payload)
 
     resultJson.isRight should be(true)

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -44,7 +44,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Monthly, Some(dd), Some(mandateId)
+      "UK", "", Monthly, Some("sfContactId"), Some("identityId"), Some(dd), Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -62,6 +62,8 @@ class SendThankYouEmailSpec extends LambdaSpec {
       user,
       GBP,
       dd,
+      Some("sfContactId"),
+      Some("identityId"),
       Some(mandateId)
     )
     val service = new EmailService
@@ -71,7 +73,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   "EmailFields" should "include Direct Debit fields in the payload" in {
     val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
     val mandateId = "65HK26E"
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, Some(dd), Some(mandateId))
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 20, Currency.GBP, "UK", "", Monthly, Some("sfContactId"), Some("identityId"), Some(dd), Some(mandateId))
     val resultJson = parse(ef.payload)
 
     resultJson.isRight should be(true)
@@ -87,7 +89,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
   }
 
   it should "still work without a Payment Method" in {
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly)
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly, Some("sfContactId"), Some("identityId"))
     val resultJson = parse(ef.payload)
     resultJson.isRight should be(true)
     (resultJson.right.get \\ "payment method").isEmpty should be(true)

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -86,6 +86,8 @@ class SendThankYouEmailSpec extends LambdaSpec {
       .validate("first payment date", "Monday, 10 January 2000")
       .validate("payment method", "Direct Debit")
       .validate("currency", "£")
+      .validate("SfContactId", "sfContactId")
+      .validate("IdentityUserId", "identityId")
   }
 
   it should "still work without a Payment Method" in {

--- a/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -27,7 +27,7 @@ class FailureHandlerSpec extends LambdaSpec {
     val service = new EmailService
     val email = "rupert.bates@theguardian.com"
     service
-      .send(FailedContributionEmailFields(email))
+      .send(FailedContributionEmailFields(email, Some("sfContactId"), Some("identityId")))
       .map(result => result.getMessageId should not be "")
   }
 
@@ -60,7 +60,6 @@ class FailureHandlerSpec extends LambdaSpec {
 
     requestInfo.failed should be(true)
     checkoutFailureState.checkoutFailureReason should be(Unknown)
-
 
   }
 
@@ -122,7 +121,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     val emailService = mock[EmailService]
     val result = mock[SendMessageResult]
-    val testFields = FailedDigitalPackEmailFields("test@gu.com")
+    val testFields = FailedDigitalPackEmailFields("test@gu.com", Some("sfContactId"), Some("identityId"))
 
     when(emailService.send(testFields)).thenReturn(Future.successful(result))
 

--- a/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.lambdas
 
 import java.io.ByteArrayOutputStream
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields}
+import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields, IdentityUserId}
 import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.Fixtures._
 import com.gu.support.workers.encoding.Conversions.{FromOutputStream, StringInputStreamConversions}
@@ -27,7 +27,7 @@ class FailureHandlerSpec extends LambdaSpec {
     val service = new EmailService
     val email = "rupert.bates@theguardian.com"
     service
-      .send(FailedContributionEmailFields(email, Some("sfContactId"), Some("identityId")))
+      .send(FailedContributionEmailFields(email, IdentityUserId("identityId")))
       .map(result => result.getMessageId should not be "")
   }
 
@@ -121,7 +121,7 @@ class FailureHandlerSpec extends LambdaSpec {
 
     val emailService = mock[EmailService]
     val result = mock[SendMessageResult]
-    val testFields = FailedDigitalPackEmailFields("test@gu.com", Some("sfContactId"), Some("identityId"))
+    val testFields = FailedDigitalPackEmailFields("test@gu.com", IdentityUserId("identityId"))
 
     when(emailService.send(testFields)).thenReturn(Future.successful(result))
 


### PR DESCRIPTION
## Changes

Add sfContactId and Identity userId to the email payload.  The messages are consumed by membership-workflow which triggers the emails. In Braze emails we upsert users using the sfContactId as the primary key. membership-workflow can resolve the sfContactId from the identity user id

## Why are you doing this?

We are migrating from our CMT providers, from ET to Braze