### PR TITLE
configurable thank you email queue name

### DIFF
--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -50,6 +50,11 @@ Resources:
               - sqs:GetQueueUrl
               - sqs:SendMessage
               Resource: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks
+            - Effect: Allow
+              Action:
+              - sqs:GetQueueUrl
+              - sqs:SendMessage
+              Resource: arn:aws:sqs:eu-west-1:865473395570:contributions-thanks-dev
         - PolicyName: CloudWatchLogging
           PolicyDocument:
             Version: '2012-10-17'

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -84,3 +84,5 @@ touchpoint.backend.environments {
     }
   }
 }
+
+email.thankYou.queueName = contributions-thanks-dev

--- a/src/main/scala/com/gu/config/Configuration.scala
+++ b/src/main/scala/com/gu/config/Configuration.scala
@@ -29,4 +29,6 @@ object Configuration {
   val payPalConfigProvider = new PayPalConfigProvider(config, stage)
   val salesforceConfigProvider = new SalesforceConfigProvider(config, stage)
   val zuoraConfigProvider = new ZuoraConfigProvider(config, stage)
+
+  val contributionThanksQueueName = config.getString("email.thankYou.queueName")
 }

--- a/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -4,6 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
 import com.gu.aws.{AwsAsync, CredentialsProvider}
+import com.gu.config.Configuration
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 
@@ -17,8 +18,7 @@ class EmailService(implicit val executionContext: ExecutionContext) {
     .withRegion(Regions.EU_WEST_1)
     .build()
 
-  private val queueName = "contributions-thanks"
-  private val queueUrl = sqsClient.getQueueUrl(queueName).getQueueUrl
+  private val queueUrl = sqsClient.getQueueUrl(Configuration.contributionThanksQueueName).getQueueUrl
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
     SafeLogger.info(s"Sending message to SQS queue $queueUrl")


### PR DESCRIPTION
## Why are you doing this?

We need to be able to configure CODE to use the CODE queues. This is necessary for testing Braze emails sent by membership-workflow in CODE.

## Changes

* configurable thank you email queue name

