### PR TITLE
send payment type to email send sqs queue

### DIFF
--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -1,7 +1,7 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency
-import com.gu.support.workers.model.{BillingPeriod, DirectDebitPaymentMethod, PaymentMethod}
+import com.gu.support.workers.model._
 import org.joda.time.DateTime
 import com.gu.salesforce.Salesforce.SfContactId
 
@@ -14,12 +14,12 @@ case class ContributionEmailFields(
     name: String,
     billingPeriod: BillingPeriod,
     sfContactId: SfContactId,
-    paymentMethod: Option[PaymentMethod] = None,
+    paymentMethod: PaymentMethod,
     directDebitMandateId: Option[String] = None
 ) extends EmailFields {
 
   val paymentFields = paymentMethod match {
-    case Some(dd: DirectDebitPaymentMethod) => List(
+    case dd: DirectDebitPaymentMethod => List(
       "account name" -> dd.bankTransferAccountName,
       "account number" -> mask(dd.bankTransferAccountNumber),
       "sort code" -> hyphenate(dd.bankCode),
@@ -27,7 +27,8 @@ case class ContributionEmailFields(
       "first payment date" -> formatDate(created.plusDays(10)),
       "payment method" -> "Direct Debit"
     )
-    case _ => Nil
+    case _: PayPalReferenceTransaction => List("payment method" -> "paypal")
+    case _: CreditCardReferenceTransaction => List("payment method" -> "card")
   }
 
   override val fields = List(

--- a/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -57,7 +57,7 @@ case class DigitalPackEmailFields(
       "MandateID" -> directDebitMandateId.getOrElse("")
     )
     case _: CreditCardReferenceTransaction => List("Default payment method" -> "Credit/Debit Card")
-    case _ => Seq("Default payment method" -> "PayPal")
+    case _: PayPalReferenceTransaction => Seq("Default payment method" -> "PayPal")
   }
 
   override val fields = List(

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -52,7 +52,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           name = state.user.firstName,
           billingPeriod = state.product.billingPeriod,
           sfContactId = SfContactId(state.salesForceContact.Id),
-          paymentMethod = Some(state.paymentMethod),
+          paymentMethod = state.paymentMethod,
           directDebitMandateId = directDebitMandateId
         )
         case d: DigitalPack => DigitalPackEmailFields(

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -45,7 +45,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Monthly, SfContactId("sfContactId"), Some(dd), Some(mandateId)
+      "UK", "", Monthly, SfContactId("sfContactId"), dd, Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -82,7 +82,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       "",
       Monthly,
       SfContactId("sfContactId"),
-      Some(dd),
+      dd,
       Some(mandateId)
     )
     val resultJson = parse(ef.payload)
@@ -101,7 +101,8 @@ class SendThankYouEmailSpec extends LambdaSpec {
   }
 
   it should "still work without a Payment Method" in {
-    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly, SfContactId("sfContactId"))
+    val dd = DirectDebitPaymentMethod("Mickey", "Mouse", "Mickey Mouse", "123456", "55779911")
+    val ef = ContributionEmailFields("", new DateTime(1999, 12, 31, 11, 59), 0, Currency.GBP, "UK", "", Monthly, SfContactId("sfContactId"), dd)
     val resultJson = parse(ef.payload)
     resultJson.isRight should be(true)
     (resultJson.right.get \\ "payment method").isEmpty should be(true)


### PR DESCRIPTION
### Why are you doing this?

The service email templates will render content depending on payment type

### What are the changes?

Add payment method name to SubscriberAttributes sent to Exact Target and Braze. These are used by the email templates.