### PR TITLE
allow creation of a second recurring contribution after 10 minutes

### DIFF
--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -1,5 +1,7 @@
 package com.gu.support.workers.lambdas
 
+import java.time.LocalDateTime
+
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
@@ -25,7 +27,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     context: Context,
     services: Services
   ): FutureHandlerResult =
-    services.zuoraService.getRecurringSubscription(state.user.id, state.product.billingPeriod).flatMap {
+    GetRecurringSubscription(services.zuoraService, LocalDateTime.now(), state.user.id, state.product.billingPeriod).flatMap {
       case Some(sub) => skipSubscribe(state, requestInfo, sub)
       case None => subscribe(state, requestInfo, services)
     }

--- a/src/main/scala/com/gu/support/workers/lambdas/GetRecurringSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/GetRecurringSubscription.scala
@@ -1,0 +1,46 @@
+package com.gu.support.workers.lambdas
+
+import java.time.LocalDateTime
+
+import cats.implicits._
+import com.gu.support.workers.model.BillingPeriod
+import com.gu.zuora.GetAccountForIdentity.DomainAccount
+import com.gu.zuora.ZuoraConfig.RatePlanId
+import com.gu.zuora.ZuoraService
+import com.gu.zuora.model.response.{RatePlan, Subscription}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object GetRecurringSubscription {
+
+  def apply(zuoraService: ZuoraService, now: LocalDateTime, identityId: String, billingPeriod: BillingPeriod): Future[Option[Subscription]] = {
+
+    val productRatePlanId = Option(zuoraService.config).map(_.contributionConfig(billingPeriod).productRatePlanId)
+
+    def hasContributorPlan(sub: Subscription): Boolean =
+      productRatePlanId match {
+        case Some(productRatePlanId) => GetRecurringSubscription.hasContributorPlan(productRatePlanId, sub.ratePlans)
+        case None => false
+      }
+
+    def isRecent(domainAccount: DomainAccount): Boolean =
+      GetRecurringSubscription.isRecent(now, domainAccount.createdDate)
+
+    for {
+      accountIds <- zuoraService.getAccountFields(identityId)
+      recentAccountIds = accountIds.filter(isRecent).map(_.accountNumber)
+      subscriptions <- recentAccountIds.map(zuoraService.getSubscriptions).combineAll
+      maybeRecentCont = subscriptions.find(sub => hasContributorPlan(sub) && sub.isActive)
+    } yield maybeRecentCont
+  }
+
+  def isRecent(now: LocalDateTime, accountCreation: LocalDateTime): Boolean = {
+    val oldestRecentTime = now.minusMinutes(10L)
+    accountCreation.isAfter(oldestRecentTime)
+  }
+
+  def hasContributorPlan(ratePlanId: RatePlanId, ratePlans: List[RatePlan]): Boolean =
+    ratePlans.exists(_.productRatePlanId == ratePlanId)
+
+}

--- a/src/main/scala/com/gu/zuora/ZuoraConfig.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraConfig.scala
@@ -9,7 +9,7 @@ object ZuoraConfig {
   type RatePlanId = String
 }
 
-case class ZuoraContributionConfig(productRatePlanId: RatePlanId, productRatePlanChargeId: RatePlanId)
+case class ZuoraContributionConfig(productRatePlanId: RatePlanId, productRatePlanChargeId: RatePlanId /*really?*/ )
 
 case class ZuoraDigitalPackConfig(monthly: RatePlanId, quarterly: RatePlanId, annual: RatePlanId)
 

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -1,10 +1,12 @@
 package com.gu.zuora
 
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+
 import cats.data.OptionT
 import cats.implicits._
 import com.gu.helpers.WebServiceHelper
 import com.gu.okhttp.RequestRunners.FutureHttpClient
-import com.gu.support.workers.model.BillingPeriod
+import com.gu.zuora.GetAccountForIdentity.DomainAccount
 import com.gu.zuora.model.response._
 import com.gu.zuora.model.{QueryData, SubscribeRequest}
 import io.circe
@@ -14,7 +16,7 @@ import io.circe.syntax._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Option[String] = None)(implicit ec: ExecutionContext)
+class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: Option[String] = None)(implicit ec: ExecutionContext)
     extends WebServiceHelper[ZuoraErrorResponse] {
 
   override val wsUrl: String = baseUrl.getOrElse(config.url)
@@ -27,9 +29,9 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
   def getAccount(accountNumber: String): Future[GetAccountResponse] =
     get[GetAccountResponse](s"accounts/$accountNumber", authHeaders)
 
-  def getAccountIds(identityId: String): Future[List[String]] = {
-    val queryData = QueryData(s"select AccountNumber from account where IdentityId__c = '${identityId.toLong}'")
-    postJson[AccountQueryResponse](s"action/query", queryData.asJson, authHeaders).map(_.records.map(_.AccountNumber))
+  def getAccountFields(identityId: String): Future[List[DomainAccount]] = {
+    val queryData = QueryData(s"select AccountNumber, CreatedDate from account where IdentityId__c = '${identityId.toLong}'")
+    postJson[AccountQueryResponse](s"action/query", queryData.asJson, authHeaders).map(_.records.map(DomainAccount.fromAccountRecord))
   }
 
   def getSubscriptions(accountId: String): Future[List[Subscription]] =
@@ -37,12 +39,6 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
 
   def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
     postJson[List[SubscribeResponseAccount]]("action/subscribe", subscribeRequest.asJson, authHeaders)
-
-  def getRecurringSubscription(identityId: String, billingPeriod: BillingPeriod): Future[Option[Subscription]] =
-    for {
-      accountIds <- getAccountIds(identityId)
-      subscriptions <- accountIds.map(getSubscriptions).combineAll
-    } yield subscriptions.find(sub => sub.hasContributorPlan(config, billingPeriod) && sub.isActive)
 
   def getDefaultPaymentMethodId(accountNumber: String): Future[Option[String]] = {
     val queryData = QueryData(s"select defaultPaymentMethodId from Account where AccountNumber = '$accountNumber'")
@@ -68,5 +64,21 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
     //The Zuora api docs say that the subscribe action returns
     //a ZuoraErrorResponse but actually it returns a list of those.
     decode[List[ZuoraErrorResponse]](responseBody).map(_.head)
+
+}
+
+object GetAccountForIdentity {
+
+  case class DomainAccount(accountNumber: String, createdDate: LocalDateTime)
+
+  object DomainAccount {
+
+    def fromAccountRecord(accountRecord: AccountRecord): DomainAccount =
+      DomainAccount(
+        accountRecord.AccountNumber,
+        ZonedDateTime.parse(accountRecord.CreatedDate).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime
+      )
+
+  }
 
 }

--- a/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
+++ b/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
@@ -23,6 +23,6 @@ case class AccountQueryResponse(records: List[AccountRecord])
 
 case class PaymentMethodQueryResponse(records: List[PaymentMethodRecord])
 
-case class AccountRecord(AccountNumber: String)
+case class AccountRecord(AccountNumber: String, CreatedDate: String)
 
 case class PaymentMethodRecord(DefaultPaymentMethodId: String)

--- a/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
+++ b/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
@@ -21,9 +21,6 @@ case class SubscriptionsResponse(subscriptions: List[Subscription])
 
 case class Subscription(accountNumber: String, status: String, ratePlans: List[RatePlan]) {
   def isActive: Boolean = status == "Active"
-  def hasContributorPlan(config: ZuoraConfig, billingPeriod: BillingPeriod): Boolean = {
-    ratePlans.exists(_.productRatePlanId == config.contributionConfig(billingPeriod).productRatePlanId)
-  }
 }
 
 case class RatePlan(productId: String, productName: String, productRatePlanId: String)

--- a/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -62,19 +62,22 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
 
   val realService = new ZuoraService(zuoraConfigProvider.get(false), configurableFutureRunner(60.seconds))
 
-  val mockService = {
-    val z = mock[ZuoraService]
+  val mockZuoraService = {
+    val mockZuora = mock[ZuoraService]
     // Need to return None from the Zuora service `getRecurringSubscription`
     // method or the subscribe step gets skipped
-    when(z.getRecurringSubscription(any[String], any[BillingPeriod]))
-      .thenReturn(Future.successful(None))
-    when(z.subscribe(any[SubscribeRequest]))
+    // if these methods weren't coupled into one class then we could pass them separately and avoid reflection
+    when(mockZuora.getAccountFields(any[String]))
+      .thenReturn(Future.successful(Nil))
+    when(mockZuora.getSubscriptions(any[String]))
+      .thenReturn(Future.successful(Nil))
+    when(mockZuora.subscribe(any[SubscribeRequest]))
       .thenAnswer((invocation: InvocationOnMock) => realService.subscribe(invocation.getArguments.head.asInstanceOf[SubscribeRequest]))
-    z
+    mockZuora
   }
 
   val mockServiceProvider = mockServices(
-    s => s.zuoraService,
-    mockService
+    services => services.zuoraService,
+    mockZuoraService
   )
 }


### PR DESCRIPTION
## Why are you doing this?

At present there is logic in the payment flow to stop people adding a second recurring contribution.  There is also logic in the step functions to stop us adding a second zuora contribution record.  This is necessary because sometimes the zuora step isn't confirmed to have succeeded but it has actually happened in the background.  Then the retry would add an incorrect duplication.

The new payment flow doesn't require login, just the email, so we need to not leak any information to the person entering the data.

This PR relaxes the corresponding lambda check to only search for subscriptions created in the last 10 minutes.

This means that we should still catch all the retries, but removing most of the opportunity for data leakage.

[**Trello Card**](https://trello.com/c/eJnOL8se/71-make-step-functions-allow-multiple-recurring-contributions-for-one-identity-account)

## Changes

@jacobwinch @rupertbates @joelochlann @jranks123 @tsop14 let me know what you think!