### PR TITLE
use currency identitier rather than just the gyph

### DIFF
--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -35,7 +35,7 @@ case class ContributionEmailFields(
     "EmailAddress" -> email,
     "created" -> created.toString,
     "amount" -> amount.toString,
-    "currency" -> currency.glyph,
+    "currency" -> currency.identifier,
     "edition" -> edition,
     "name" -> name,
     "product" -> s"${billingPeriod.toString.toLowerCase}-contribution"


### PR DESCRIPTION
## Why are you doing this?

We want to display the currency identifier on the recurring contributor email

## Changes

Use currency identifier rather than gyph, sent to CMT provider which sends emails

