### PR TITLE
Bump jackson-databind version and jackson-annotations to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ lazy val root = (project in file("."))
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,
+      // This is required to force aws libraries to use the latest version of jackson
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7",
       "org.scalatest" %% "scalatest" % "3.0.5" % "it,test",
       "org.mockito" % "mockito-core" % "1.9.5" % "it,test",
       "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "it,test",


### PR DESCRIPTION
## Why are you doing this?
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested [here](https://github.com/aws/aws-sdk-java) that this shouldn't be a breaking change for the aws sdks, and indeed when I tested it on CODE, it wasn't. I bumped the version, signed in with a test user, then signed up for a recurring contribution that succeeded. I then also tried with a stripe card that I knew should fail. I checked that the executions of the state machines behaved as expected, and that a subscription was set up in Zuora for the happy case, and that it wasn't on expected error. 

Any other suggested checks?
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com) // none. Inspired by Snyk.

## Changes

* Bumped jackson-databind and jackson-annotations to 2.9.7