### PR TITLE
Upgrade dispatch to 0.14.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val root = (project in file("."))
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-generic-extras" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "net.databinder.dispatch" %% "dispatch-core" % "0.13.3",
+      "org.dispatchhttp" %% "dispatch-core" % "0.14.0",
       "org.scala-stm" %% "scala-stm" % "0.8",
       "io.sentry" % "sentry-logback" % "1.7.4",
       "com.google.code.findbugs" % "jsr305" % "3.0.2"


### PR DESCRIPTION
## Why are you doing this?
[https://app.snyk.io/vuln/SNYK-JAVA-ORGBEANSHELL-72452](https://app.snyk.io/vuln/SNYK-JAVA-ORGBEANSHELL-72452)

Due to having an old version of dispatch, we had a dependency, specifically beanshell, which had the above security issue. 

I've tested putting through a recurring contribution on CODE and it works just fine. 