### PR TITLE
use the session id to decide which zuora accounts to deduplicate against

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.34",
+      "com.gu" %% "support-models" % "0.35-SNAPSHOT",
       "com.gu" %% "support-config" % "0.16",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
       "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.35-SNAPSHOT",
+      "com.gu" %% "support-models" % "0.35",
       "com.gu" %% "support-config" % "0.16",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
       "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import sbt.Keys.{libraryDependencies, resolvers}
 import scalariform.formatter.preferences.SpacesAroundMultiImports
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.7"
 organization := "com.gu"
 version := "0.1-SNAPSHOT"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
@@ -43,7 +43,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.32",
+      "com.gu" %% "support-models" % "0.34",
       "com.gu" %% "support-config" % "0.16",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
       "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
@@ -1,0 +1,54 @@
+package com.gu.support.workers
+
+import cats.implicits._
+import com.gu.support.workers.lambdas.IdentityId
+import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
+import com.gu.support.workers.model.{AccessScope, BillingPeriod}
+import com.gu.zuora.GetAccountForIdentity.DomainAccount
+import com.gu.zuora.GetSubscription.DomainSubscription
+import com.gu.zuora.ZuoraConfig.RatePlanId
+import com.gu.zuora.ZuoraService
+import com.gu.zuora.model.response.RatePlan
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object GetRecurringSubscription {
+
+  def apply(
+    zuoraService: ZuoraService,
+    accessScope: AccessScope,
+    identityId: IdentityId,
+    billingPeriod: BillingPeriod
+  )(implicit ec: ExecutionContext): Future[Option[DomainSubscription]] = {
+
+    val productRatePlanId = Option(zuoraService.config).map(_.contributionConfig(billingPeriod).productRatePlanId)
+
+    def hasContributorPlan(sub: DomainSubscription): Boolean =
+      productRatePlanId match {
+        case Some(productRatePlanId) => GetRecurringSubscription.hasContributorPlan(productRatePlanId, sub.ratePlans)
+        case None => false
+      }
+
+    def isInScope(domainAccount: DomainAccount): Boolean =
+      GetRecurringSubscription.isInAccessScope(accessScope, domainAccount.maybeCreatedSessionId)
+
+    for {
+      accountIds <- zuoraService.getAccountFields(identityId)
+      inScopeAccountIds = accountIds.filter(isInScope).map(_.accountNumber)
+      subscriptions <- inScopeAccountIds.map(zuoraService.getSubscriptions).combineAll
+      maybeRecentCont = subscriptions.find(sub => hasContributorPlan(sub) && sub.isActive.value)
+    } yield maybeRecentCont
+  }
+
+  def isInAccessScope(accessScope: AccessScope, maybeCreatedSessionId: Option[SessionId]): Boolean = {
+    (accessScope, maybeCreatedSessionId) match {
+      case (AccessScopeNoRestriction, _) => true
+      case (AccessScopeBySessionId(currentSessionId), Some(existingSubSession)) if currentSessionId == existingSubSession => true
+      case _ => false
+    }
+  }
+
+  def hasContributorPlan(ratePlanId: RatePlanId, ratePlans: List[RatePlan]): Boolean =
+    ratePlans.exists(_.productRatePlanId == ratePlanId)
+
+}

--- a/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers
 
 import cats.implicits._
+import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.lambdas.IdentityId
 import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
 import com.gu.support.workers.model.{AccessScope, BillingPeriod}
@@ -29,8 +30,11 @@ object GetRecurringSubscription {
         case None => false
       }
 
-    def isInScope(domainAccount: DomainAccount): Boolean =
-      GetRecurringSubscription.isInAccessScope(accessScope, domainAccount.maybeCreatedSessionId)
+    def isInScope(domainAccount: DomainAccount): Boolean = {
+      val inScope = GetRecurringSubscription.isInAccessScope(accessScope, domainAccount.maybeCreatedSessionId)
+      SafeLogger.info(s"isInScope $inScope when using access scope $accessScope to check account $domainAccount")
+      inScope
+    }
 
     for {
       accountIds <- zuoraService.getAccountFields(identityId)

--- a/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/GetRecurringSubscription.scala
@@ -3,8 +3,8 @@ package com.gu.support.workers
 import cats.implicits._
 import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.lambdas.IdentityId
-import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
-import com.gu.support.workers.model.{AccessScope, BillingPeriod}
+import com.gu.support.workers.model.AccountAccessScope.{SessionAccess, AuthenticatedAccess, SessionId}
+import com.gu.support.workers.model.{AccountAccessScope, BillingPeriod}
 import com.gu.zuora.GetAccountForIdentity.{CreatedInSession, DomainAccount, ExistingContributionSessionId}
 import com.gu.zuora.GetSubscription.DomainSubscription
 import com.gu.zuora.ZuoraConfig.RatePlanId
@@ -17,7 +17,7 @@ object GetRecurringSubscription {
 
   def apply(
     zuoraService: ZuoraService,
-    accessScope: AccessScope,
+    accessScope: AccountAccessScope,
     identityId: IdentityId,
     billingPeriod: BillingPeriod
   )(implicit ec: ExecutionContext): Future[Option[DomainSubscription]] = {
@@ -54,10 +54,10 @@ object GetRecurringSubscription {
 
 object IsAccountAccessAllowed {
 
-  def apply(accessScope: AccessScope, existingAccountSessionId: ExistingContributionSessionId): Boolean = {
+  def apply(accessScope: AccountAccessScope, existingAccountSessionId: ExistingContributionSessionId): Boolean = {
     (accessScope, existingAccountSessionId) match {
-      case (AccessScopeNoRestriction, _) => true
-      case (AccessScopeBySessionId(currentSessionId), CreatedInSession(existingSubSession)) if currentSessionId == existingSubSession => true
+      case (AuthenticatedAccess, _) => true
+      case (SessionAccess(currentSessionId), CreatedInSession(existingSubSession)) if currentSessionId == existingSubSession => true
       case _ => false
     }
   }

--- a/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -48,7 +48,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       state.user,
       state.product,
       paymentMethod,
-      state.acquisitionData
+      state.acquisitionData,
+      state.sessionId
     )
 
   def createStripePaymentMethod(stripe: StripePaymentFields, currency: Currency, stripeService: StripeService): Future[CreditCardReferenceTransaction] =

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -42,6 +42,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.product,
       state.paymentMethod,
       response.ContactRecord,
-      state.acquisitionData
+      state.acquisitionData,
+      state.sessionId
     )
 }

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -6,6 +6,7 @@ import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.GetRecurringSubscription
 import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.model.AccountAccessScope.{AuthenticatedAccess, SessionAccess, SessionId}
 import com.gu.support.workers.model.states.{CreateZuoraSubscriptionState, SendThankYouEmailState}
 import com.gu.support.workers.model.{Contribution, DigitalPack, RequestInfo}
 import com.gu.zuora.GetAccountForIdentity.ZuoraAccountNumber
@@ -129,7 +130,11 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     state.salesForceContact.AccountId, //Somewhere else we store the Salesforce Account id
     state.salesForceContact.Id,
     state.user.id,
-    PaymentGateway.forPaymentMethod(state.paymentMethod, state.product.currency)
+    PaymentGateway.forPaymentMethod(state.paymentMethod, state.product.currency),
+    state.accountAccessScope match {
+      case SessionAccess(SessionId(value)) => Some(value)
+      case AuthenticatedAccess => None
+    }
   )
 }
 

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -12,6 +12,7 @@ import com.gu.zuora.GetAccountForIdentity.ZuoraAccountNumber
 import com.gu.zuora.GetSubscription.DomainSubscription
 import com.gu.zuora.ZuoraConfig.RatePlanId
 import com.gu.zuora.model._
+import com.gu.zuora.model.response.SubscribeResponseAccount
 import org.joda.time.{DateTimeZone, LocalDate}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -43,7 +44,9 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     FutureHandlerResult(getEmailState(state, subscription.accountNumber), requestInfo.appendMessage(message))
   }
 
-  def singleSubscribe[RESULT](multiSubscribe: SubscribeRequest => Future[List[RESULT]]): SubscribeItem => Future[RESULT] = { subscribeItem =>
+  def singleSubscribe(
+    multiSubscribe: SubscribeRequest => Future[List[SubscribeResponseAccount]]
+  ): SubscribeItem => Future[SubscribeResponseAccount] = { subscribeItem =>
     multiSubscribe(SubscribeRequest(List(subscribeItem))) flatMap {
       case result :: Nil => Future.successful(result)
       case results => Future.failed(new RuntimeException(s"didn't get a single response item, got: $results"))

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -31,7 +31,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     services: Services
   ): FutureHandlerResult = for {
     identityId <- Future.fromTry(IdentityId(state.user.id))
-    maybeDomainSubscription <- GetRecurringSubscription(services.zuoraService, state.accessScope, identityId, state.product.billingPeriod)
+    maybeDomainSubscription <- GetRecurringSubscription(services.zuoraService, state.accountAccessScope, identityId, state.product.billingPeriod)
     thankYouState <- maybeDomainSubscription match {
       case Some(domainSubscription) => skipSubscribe(state, requestInfo, domainSubscription)
       case None => subscribe(state, requestInfo, services)

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -80,7 +80,7 @@ object GetAccountForIdentity {
   case object NotCreatedInSession extends ExistingContributionSessionId
   case class CreatedInSession(sessionId: SessionId) extends ExistingContributionSessionId
 
-  case class DomainAccount(accountNumber: ZuoraAccountNumber, existingContributionSessionId: ExistingContributionSessionId)
+  case class DomainAccount(accountNumber: ZuoraAccountNumber, existingAccountSessionId: ExistingContributionSessionId)
 
   object DomainAccount {
 

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -83,7 +83,7 @@ object GetAccountForIdentity {
     def fromWireAccount(accountRecord: AccountRecord): DomainAccount =
       DomainAccount(
         ZuoraAccountNumber(accountRecord.AccountNumber),
-        Some(accountRecord.CreatedSessionId__c).filter(_.length > 0).map(SessionId.apply)
+        accountRecord.CreatedSessionId__c.filter(_.length > 0).map(SessionId.apply)
       )
 
   }

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import com.gu.helpers.WebServiceHelper
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.support.workers.lambdas.IdentityId
-import com.gu.support.workers.model.AccessScope.SessionId
+import com.gu.support.workers.model.AccountAccessScope.SessionId
 import com.gu.zuora.GetAccountForIdentity.{DomainAccount, ZuoraAccountNumber}
 import com.gu.zuora.GetSubscription.DomainSubscription
 import com.gu.zuora.model.response._

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -100,7 +100,7 @@ object GetSubscription {
       DomainSubscription(
         ZuoraAccountNumber(subscription.accountNumber),
         ZuoraIsActive(subscription.status == "Active"),
-        subscription.ratePlans //.map(DomainRatePlan.fromWire)
+        subscription.ratePlans //this can be changed to map to a DomainRatePlan if necessary
       )
   }
 }

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -4,7 +4,10 @@ import cats.data.OptionT
 import cats.implicits._
 import com.gu.helpers.WebServiceHelper
 import com.gu.okhttp.RequestRunners.FutureHttpClient
-import com.gu.support.workers.model.BillingPeriod
+import com.gu.support.workers.lambdas.IdentityId
+import com.gu.support.workers.model.AccessScope.SessionId
+import com.gu.zuora.GetAccountForIdentity.{DomainAccount, ZuoraAccountNumber}
+import com.gu.zuora.GetSubscription.DomainSubscription
 import com.gu.zuora.model.response._
 import com.gu.zuora.model.{QueryData, SubscribeRequest}
 import io.circe
@@ -14,7 +17,7 @@ import io.circe.syntax._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Option[String] = None)(implicit ec: ExecutionContext)
+class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: Option[String] = None)(implicit ec: ExecutionContext)
     extends WebServiceHelper[ZuoraErrorResponse] {
 
   override val wsUrl: String = baseUrl.getOrElse(config.url)
@@ -27,24 +30,22 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
   def getAccount(accountNumber: String): Future[GetAccountResponse] =
     get[GetAccountResponse](s"accounts/$accountNumber", authHeaders)
 
-  def getAccountIds(identityId: String): Future[List[String]] = {
-    val queryData = QueryData(s"select AccountNumber from account where IdentityId__c = '${identityId.toLong}'")
-    postJson[AccountQueryResponse](s"action/query", queryData.asJson, authHeaders).map(_.records.map(_.AccountNumber))
+  def getAccountFields(identityId: IdentityId): Future[List[DomainAccount]] = {
+    // WARNING constructing queries from strings is inherently dangerous.  Be very careful.
+    val queryData = QueryData(s"select AccountNumber, CreatedSessionId__c from account where IdentityId__c = '${identityId.value}'")
+    postJson[AccountQueryResponse](s"action/query", queryData.asJson, authHeaders).map(_.records.map(DomainAccount.fromWireAccount))
   }
 
-  def getSubscriptions(accountId: String): Future[List[Subscription]] =
-    get[SubscriptionsResponse](s"subscriptions/accounts/$accountId", authHeaders).map(_.subscriptions)
+  def getSubscriptions(accountNumber: ZuoraAccountNumber): Future[List[DomainSubscription]] =
+    get[SubscriptionsResponse](s"subscriptions/accounts/${accountNumber.value}", authHeaders).map { subscriptionsResponse =>
+      subscriptionsResponse.subscriptions.map(DomainSubscription.fromWireSubscription)
+    }
 
   def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
     postJson[List[SubscribeResponseAccount]]("action/subscribe", subscribeRequest.asJson, authHeaders)
 
-  def getRecurringSubscription(identityId: String, billingPeriod: BillingPeriod): Future[Option[Subscription]] =
-    for {
-      accountIds <- getAccountIds(identityId)
-      subscriptions <- accountIds.map(getSubscriptions).combineAll
-    } yield subscriptions.find(sub => sub.hasContributorPlan(config, billingPeriod) && sub.isActive)
-
   def getDefaultPaymentMethodId(accountNumber: String): Future[Option[String]] = {
+    // WARNING constructing queries from strings is inherently dangerous.  Be very careful.
     val queryData = QueryData(s"select defaultPaymentMethodId from Account where AccountNumber = '$accountNumber'")
     postJson[PaymentMethodQueryResponse](s"action/query", queryData.asJson, authHeaders)
       .map(r => Some(r.records.head.DefaultPaymentMethodId))
@@ -69,4 +70,37 @@ class ZuoraService(config: ZuoraConfig, client: FutureHttpClient, baseUrl: Optio
     //a ZuoraErrorResponse but actually it returns a list of those.
     decode[List[ZuoraErrorResponse]](responseBody).map(_.head)
 
+}
+
+object GetAccountForIdentity {
+
+  case class ZuoraAccountNumber(value: String)
+
+  case class DomainAccount(accountNumber: ZuoraAccountNumber, maybeCreatedSessionId: Option[SessionId])
+
+  object DomainAccount {
+
+    def fromWireAccount(accountRecord: AccountRecord): DomainAccount =
+      DomainAccount(
+        ZuoraAccountNumber(accountRecord.AccountNumber),
+        Some(accountRecord.CreatedSessionId__c).filter(_.length > 0).map(SessionId.apply)
+      )
+
+  }
+
+}
+
+object GetSubscription {
+
+  case class ZuoraIsActive(value: Boolean) extends AnyVal
+
+  case class DomainSubscription(accountNumber: ZuoraAccountNumber, isActive: ZuoraIsActive, ratePlans: List[RatePlan])
+  object DomainSubscription {
+    def fromWireSubscription(subscription: Subscription): DomainSubscription =
+      DomainSubscription(
+        ZuoraAccountNumber(subscription.accountNumber),
+        ZuoraIsActive(subscription.status == "Active"),
+        subscription.ratePlans //.map(DomainRatePlan.fromWire)
+      )
+  }
 }

--- a/src/main/scala/com/gu/zuora/model/Account.scala
+++ b/src/main/scala/com/gu/zuora/model/Account.scala
@@ -16,6 +16,7 @@ case class Account(
   sfContactId__c: String, //Salesforce contactId - if this field name changes then change the encoder in CustomCodecs
   identityId__c: String,
   paymentGateway: PaymentGateway,
+  CreatedSessionId__c: Option[String],
   billCycleDay: Int = 0,
   autoPay: Boolean = true,
   paymentTerm: String = "Due Upon Receipt",

--- a/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
+++ b/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
@@ -23,6 +23,6 @@ case class AccountQueryResponse(records: List[AccountRecord])
 
 case class PaymentMethodQueryResponse(records: List[PaymentMethodRecord])
 
-case class AccountRecord(AccountNumber: String)
+case class AccountRecord(AccountNumber: String, CreatedSessionId__c: String)
 
 case class PaymentMethodRecord(DefaultPaymentMethodId: String)

--- a/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
+++ b/src/main/scala/com/gu/zuora/model/response/QueryResponse.scala
@@ -23,6 +23,6 @@ case class AccountQueryResponse(records: List[AccountRecord])
 
 case class PaymentMethodQueryResponse(records: List[PaymentMethodRecord])
 
-case class AccountRecord(AccountNumber: String, CreatedSessionId__c: String)
+case class AccountRecord(AccountNumber: String, CreatedSessionId__c: Option[String])
 
 case class PaymentMethodRecord(DefaultPaymentMethodId: String)

--- a/src/main/scala/com/gu/zuora/model/response/Responses.scala
+++ b/src/main/scala/com/gu/zuora/model/response/Responses.scala
@@ -32,7 +32,7 @@ object ZuoraErrorResponse {
 }
 
 case class ZuoraErrorResponse(success: Boolean, errors: List[ZuoraError])
-  extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
+    extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
 
   override def toString: String = this.errors.toString()
   def toRetryNone: RetryNone = new RetryNone(message = this.asJson.noSpaces, cause = this)
@@ -77,20 +77,20 @@ object SubscribeResponseAccount {
   implicit val codec: Codec[SubscribeResponseAccount] = capitalizingCodec
 }
 case class SubscribeResponseAccount(
-  accountNumber: String,
-  subscriptionNumber: String,
-  gatewayResponse: String,
-  paymentId: String,
-  invoiceResult: InvoiceResult,
-  totalTcv: Float,
-  subscriptionId: String,
-  totalMrr: Float,
-  paymentTransactionNumber: String,
-  accountId: String,
-  gatewayResponseCode: String,
-  invoiceNumber: String,
-  invoiceId: String,
-  success: Boolean
+    accountNumber: String,
+    subscriptionNumber: String,
+    gatewayResponse: String,
+    paymentId: String,
+    invoiceResult: InvoiceResult,
+    totalTcv: Float,
+    subscriptionId: String,
+    totalMrr: Float,
+    paymentTransactionNumber: String,
+    accountId: String,
+    gatewayResponseCode: String,
+    invoiceNumber: String,
+    invoiceId: String,
+    success: Boolean
 ) extends ZuoraResponse {
 
   def domainAccountNumber: ZuoraAccountNumber = ZuoraAccountNumber(accountNumber)

--- a/src/main/scala/com/gu/zuora/model/response/Responses.scala
+++ b/src/main/scala/com/gu/zuora/model/response/Responses.scala
@@ -32,7 +32,7 @@ object ZuoraErrorResponse {
 }
 
 case class ZuoraErrorResponse(success: Boolean, errors: List[ZuoraError])
-    extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
+  extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
 
   override def toString: String = this.errors.toString()
   def toRetryNone: RetryNone = new RetryNone(message = this.asJson.noSpaces, cause = this)
@@ -77,20 +77,20 @@ object SubscribeResponseAccount {
   implicit val codec: Codec[SubscribeResponseAccount] = capitalizingCodec
 }
 case class SubscribeResponseAccount(
-    accountNumber: String,
-    subscriptionNumber: String,
-    gatewayResponse: String,
-    paymentId: String,
-    invoiceResult: InvoiceResult,
-    totalTcv: Float,
-    subscriptionId: String,
-    totalMrr: Float,
-    paymentTransactionNumber: String,
-    accountId: String,
-    gatewayResponseCode: String,
-    invoiceNumber: String,
-    invoiceId: String,
-    success: Boolean
+  accountNumber: String,
+  subscriptionNumber: String,
+  gatewayResponse: String,
+  paymentId: String,
+  invoiceResult: InvoiceResult,
+  totalTcv: Float,
+  subscriptionId: String,
+  totalMrr: Float,
+  paymentTransactionNumber: String,
+  accountId: String,
+  gatewayResponseCode: String,
+  invoiceNumber: String,
+  invoiceId: String,
+  success: Boolean
 ) extends ZuoraResponse {
 
   def domainAccountNumber: ZuoraAccountNumber = ZuoraAccountNumber(accountNumber)

--- a/src/main/scala/com/gu/zuora/model/response/Responses.scala
+++ b/src/main/scala/com/gu/zuora/model/response/Responses.scala
@@ -3,6 +3,7 @@ package com.gu.zuora.model.response
 import com.gu.support.workers.encoding.Helpers.{capitalizingCodec, deriveCodec}
 import com.gu.support.workers.encoding.{Codec, ErrorJson}
 import com.gu.support.workers.exceptions.{RetryException, RetryNone, RetryUnlimited}
+import com.gu.zuora.GetAccountForIdentity.ZuoraAccountNumber
 import io.circe.parser._
 import io.circe.syntax._
 
@@ -31,7 +32,7 @@ object ZuoraErrorResponse {
 }
 
 case class ZuoraErrorResponse(success: Boolean, errors: List[ZuoraError])
-    extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
+  extends Throwable(errors.asJson.spaces2) with ZuoraResponse {
 
   override def toString: String = this.errors.toString()
   def toRetryNone: RetryNone = new RetryNone(message = this.asJson.noSpaces, cause = this)
@@ -90,7 +91,11 @@ case class SubscribeResponseAccount(
   invoiceNumber: String,
   invoiceId: String,
   success: Boolean
-) extends ZuoraResponse
+) extends ZuoraResponse {
+
+  def domainAccountNumber: ZuoraAccountNumber = ZuoraAccountNumber(accountNumber)
+
+}
 
 object InvoiceResult {
   implicit val codec: Codec[InvoiceResult] = capitalizingCodec

--- a/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
+++ b/src/main/scala/com/gu/zuora/model/response/SubscriptionsResponse.scala
@@ -19,12 +19,7 @@ object RatePlan {
 
 case class SubscriptionsResponse(subscriptions: List[Subscription])
 
-case class Subscription(accountNumber: String, status: String, ratePlans: List[RatePlan]) {
-  def isActive: Boolean = status == "Active"
-  def hasContributorPlan(config: ZuoraConfig, billingPeriod: BillingPeriod): Boolean = {
-    ratePlans.exists(_.productRatePlanId == config.contributionConfig(billingPeriod).productRatePlanId)
-  }
-}
+case class Subscription(accountNumber: String, status: String, ratePlans: List[RatePlan])
 
 case class RatePlan(productId: String, productName: String, productRatePlanId: String)
 

--- a/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
+++ b/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
@@ -1,19 +1,19 @@
 package com.gu.support.workers
 
-import com.gu.support.workers.model.AccessScope
-import com.gu.support.workers.model.AccessScope._
+import com.gu.support.workers.model.AccountAccessScope
+import com.gu.support.workers.model.AccountAccessScope._
 import org.scalatest.{FlatSpec, Matchers}
 
-class AccessScopeCodecTest extends FlatSpec with Matchers {
+class AccountAccessScopeCodecTest extends FlatSpec with Matchers {
 
   it should "for backwards compatibility, deserialise when it's not specified to no restriction" in {
-    val actual = AccessScope.fromRaw(None)
-    actual should be(AccessScopeNoRestriction)
+    val actual = AccountAccessScope.fromWire(None)
+    actual should be(AuthenticatedAccess)
   }
 
   it should "deserialise when it's got a value to token scope" in {
-    val actual = AccessScope.fromRaw(Some("hello"))
-    actual should be(AccessScopeBySessionId(SessionId("hello")))
+    val actual = AccountAccessScope.fromWire(Some("hello"))
+    actual should be(SessionAccess(SessionId("hello")))
   }
 
 }

--- a/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
+++ b/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
@@ -7,12 +7,12 @@ import org.scalatest.{FlatSpec, Matchers}
 class AccountAccessScopeCodecTest extends FlatSpec with Matchers {
 
   it should "for backwards compatibility, deserialise when it's not specified to no restriction" in {
-    val actual = AccountAccessScope.fromWire(None)
+    val actual = AccountAccessScope.fromInput(None)
     actual should be(AuthenticatedAccess)
   }
 
   it should "deserialise when it's got a value to token scope" in {
-    val actual = AccountAccessScope.fromWire(Some("hello"))
+    val actual = AccountAccessScope.fromInput(Some("hello"))
     actual should be(SessionAccess(SessionId("hello")))
   }
 

--- a/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
+++ b/src/test/scala/com/gu/support/workers/AccessScopeCodecTest.scala
@@ -1,0 +1,19 @@
+package com.gu.support.workers
+
+import com.gu.support.workers.model.AccessScope
+import com.gu.support.workers.model.AccessScope._
+import org.scalatest.{FlatSpec, Matchers}
+
+class AccessScopeCodecTest extends FlatSpec with Matchers {
+
+  it should "for backwards compatibility, deserialise when it's not specified to no restriction" in {
+    val actual = AccessScope.fromRaw(None)
+    actual should be(AccessScopeNoRestriction)
+  }
+
+  it should "deserialise when it's got a value to token scope" in {
+    val actual = AccessScope.fromRaw(Some("hello"))
+    actual should be(AccessScopeBySessionId(SessionId("hello")))
+  }
+
+}

--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -122,7 +122,7 @@ object Fixtures {
       }
     """
 
-  def createPayPalPaymentMethodContributionJson(currency: Currency = GBP) =
+  def createPayPalPaymentMethodContributionJson(currency: Currency = GBP): String =
     s"""{
           $requestIdJson,
           $userJson,
@@ -131,12 +131,13 @@ object Fixtures {
           "acquisitionData": $acquisitionData
         }"""
 
-  def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5) =
+  def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5): String =
     s"""{
           $requestIdJson,
           $userJson,
           "product": ${contribution(amount = amount, billingPeriod = billingPeriod)},
-          "paymentFields": $stripeJson
+          "paymentFields": $stripeJson,
+          "sessionId": "testingToken"
         }"""
 
   val oldSchemaContributionJson =
@@ -173,7 +174,7 @@ object Fixtures {
           }
         """
 
-  def thankYouEmailJson(product: String = contribution()) =
+  def thankYouEmailJson(product: String = contribution()): String =
     s"""{
        |  $requestIdJson,
        |  $userJson,

--- a/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
+++ b/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
@@ -1,29 +1,29 @@
 package com.gu.support.workers
 
-import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
+import com.gu.support.workers.model.AccountAccessScope.{SessionAccess, AuthenticatedAccess, SessionId}
 import com.gu.zuora.GetAccountForIdentity.{CreatedInSession, NotCreatedInSession}
 import org.scalatest.{FlatSpec, Matchers}
 
-class GetRecurringSubscriptionIsInAccessScopeSpec extends FlatSpec with Matchers {
+class GetRecurringSubscriptionIsInAccountAccessScopeSpec extends FlatSpec with Matchers {
 
   it should "allow access to unlabelled accounts where there is no restriction" in {
-    IsAccountAccessAllowed(AccessScopeNoRestriction, NotCreatedInSession) should be(true)
+    IsAccountAccessAllowed(AuthenticatedAccess, NotCreatedInSession) should be(true)
   }
 
   it should "allow access to labelled accounts where there is no restriction" in {
-    IsAccountAccessAllowed(AccessScopeNoRestriction, CreatedInSession(SessionId("existing"))) should be(true)
+    IsAccountAccessAllowed(AuthenticatedAccess, CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "allow access to labelled accounts where there is a restriction to that label" in {
-    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("existing")), CreatedInSession(SessionId("existing"))) should be(true)
+    IsAccountAccessAllowed(SessionAccess(SessionId("existing")), CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "NOT allow access to unlabelled accounts where there is a restriction" in {
-    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), NotCreatedInSession) should be(false)
+    IsAccountAccessAllowed(SessionAccess(SessionId("restricted")), NotCreatedInSession) should be(false)
   }
 
   it should "NOT allow access to labelled accounts where there is a conflicting restriction" in {
-    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), CreatedInSession(SessionId("existing"))) should be(false)
+    IsAccountAccessAllowed(SessionAccess(SessionId("restricted")), CreatedInSession(SessionId("existing"))) should be(false)
   }
 
 }

--- a/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
+++ b/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
@@ -7,23 +7,23 @@ import org.scalatest.{FlatSpec, Matchers}
 class GetRecurringSubscriptionIsInAccessScopeSpec extends FlatSpec with Matchers {
 
   it should "allow access to unlabelled accounts where there is no restriction" in {
-    IsSubscriptionAccessAllowed(AccessScopeNoRestriction, NotCreatedInSession) should be(true)
+    IsAccountAccessAllowed(AccessScopeNoRestriction, NotCreatedInSession) should be(true)
   }
 
   it should "allow access to labelled accounts where there is no restriction" in {
-    IsSubscriptionAccessAllowed(AccessScopeNoRestriction, CreatedInSession(SessionId("existing"))) should be(true)
+    IsAccountAccessAllowed(AccessScopeNoRestriction, CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "allow access to labelled accounts where there is a restriction to that label" in {
-    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("existing")), CreatedInSession(SessionId("existing"))) should be(true)
+    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("existing")), CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "NOT allow access to unlabelled accounts where there is a restriction" in {
-    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), NotCreatedInSession) should be(false)
+    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), NotCreatedInSession) should be(false)
   }
 
   it should "NOT allow access to labelled accounts where there is a conflicting restriction" in {
-    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), CreatedInSession(SessionId("existing"))) should be(false)
+    IsAccountAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), CreatedInSession(SessionId("existing"))) should be(false)
   }
 
 }

--- a/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
+++ b/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
@@ -1,0 +1,28 @@
+package com.gu.support.workers
+
+import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
+import org.scalatest.{FlatSpec, Matchers}
+
+class GetRecurringSubscriptionIsInAccessScopeSpec extends FlatSpec with Matchers {
+
+  it should "allow access to unlabelled accounts where there is no restriction" in {
+    GetRecurringSubscription.isInAccessScope(AccessScopeNoRestriction, None) should be(true)
+  }
+
+  it should "allow access to labelled accounts where there is no restriction" in {
+    GetRecurringSubscription.isInAccessScope(AccessScopeNoRestriction, Some(SessionId("existing"))) should be(true)
+  }
+
+  it should "allow access to labelled accounts where there is a restriction to that label" in {
+    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("existing")), Some(SessionId("existing"))) should be(true)
+  }
+
+  it should "NOT allow access to unlabelled accounts where there is a restriction" in {
+    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("restricted")), None) should be(false)
+  }
+
+  it should "NOT allow access to labelled accounts where there is a conflicting restriction" in {
+    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("restricted")), Some(SessionId("existing"))) should be(false)
+  }
+
+}

--- a/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
+++ b/src/test/scala/com/gu/support/workers/GetRecurringSubscriptionIsInAccessScopeSpec.scala
@@ -1,28 +1,29 @@
 package com.gu.support.workers
 
 import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
+import com.gu.zuora.GetAccountForIdentity.{CreatedInSession, NotCreatedInSession}
 import org.scalatest.{FlatSpec, Matchers}
 
 class GetRecurringSubscriptionIsInAccessScopeSpec extends FlatSpec with Matchers {
 
   it should "allow access to unlabelled accounts where there is no restriction" in {
-    GetRecurringSubscription.isInAccessScope(AccessScopeNoRestriction, None) should be(true)
+    IsSubscriptionAccessAllowed(AccessScopeNoRestriction, NotCreatedInSession) should be(true)
   }
 
   it should "allow access to labelled accounts where there is no restriction" in {
-    GetRecurringSubscription.isInAccessScope(AccessScopeNoRestriction, Some(SessionId("existing"))) should be(true)
+    IsSubscriptionAccessAllowed(AccessScopeNoRestriction, CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "allow access to labelled accounts where there is a restriction to that label" in {
-    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("existing")), Some(SessionId("existing"))) should be(true)
+    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("existing")), CreatedInSession(SessionId("existing"))) should be(true)
   }
 
   it should "NOT allow access to unlabelled accounts where there is a restriction" in {
-    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("restricted")), None) should be(false)
+    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), NotCreatedInSession) should be(false)
   }
 
   it should "NOT allow access to labelled accounts where there is a conflicting restriction" in {
-    GetRecurringSubscription.isInAccessScope(AccessScopeBySessionId(SessionId("restricted")), Some(SessionId("existing"))) should be(false)
+    IsSubscriptionAccessAllowed(AccessScopeBySessionId(SessionId("restricted")), CreatedInSession(SessionId("existing"))) should be(false)
   }
 
 }

--- a/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers.lambdas
 import com.gu.i18n.Currency.GBP
 import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.model.AccessScope._
 import com.gu.support.workers.model._
 import com.gu.support.workers.model.states.CreatePaymentMethodState
 import com.gu.zuora.encoding.CustomCodecs._
@@ -46,31 +47,27 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
   }
 
   "CreatePaymentMethodStateDecoder" should "be able to decode a contribution with PayPal payment fields" in {
-    val state = decode[CreatePaymentMethodState](createPayPalPaymentMethodContributionJson())
-    state.isRight should be(true)
-    val result = state.right.get
-    result.product match {
-      case contribution: Contribution => contribution.amount should be(5)
-      case _ => fail()
-    }
-    result.paymentFields match {
-      case paypal: PayPalPaymentFields => paypal.baid should be(validBaid)
-      case _ => fail()
-    }
+    val maybeState = decode[CreatePaymentMethodState](createPayPalPaymentMethodContributionJson())
+
+    val fieldsToTest = maybeState.map(state =>
+      (state.accessScope, state.product, state.paymentFields))
+    fieldsToTest should be(Right(
+      AccessScopeNoRestriction,
+      Contribution(5, GBP, Monthly),
+      PayPalPaymentFields(validBaid)
+    ))
 
   }
 
   it should "be able to decode a contribution with Stripe payment fields" in {
-    val state = decode[CreatePaymentMethodState](createStripePaymentMethodContributionJson())
-    val result = state.right.get
-    result.product match {
-      case contribution: Contribution => contribution.amount should be(5)
-      case _ => fail()
-    }
-    result.paymentFields match {
-      case stripe: StripePaymentFields => stripe.stripeToken should be(stripeToken)
-      case _ => fail()
-    }
+    val maybeState = decode[CreatePaymentMethodState](createStripePaymentMethodContributionJson())
+    val fieldsToTest = maybeState.map(state =>
+      (state.accessScope, state.product, state.paymentFields))
+    fieldsToTest should be(Right(
+      AccessScopeBySessionId(SessionId("testingToken")),
+      Contribution(5, GBP, Monthly),
+      StripePaymentFields(stripeToken)
+    ))
   }
 
   it should "be able to decode a DigtalBundle with PayPal payment fields" in {

--- a/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.lambdas
 import com.gu.i18n.Currency.GBP
 import com.gu.support.workers.Fixtures.{validBaid, _}
 import com.gu.support.workers.encoding.StateCodecs._
-import com.gu.support.workers.model.AccessScope._
+import com.gu.support.workers.model.AccountAccessScope._
 import com.gu.support.workers.model._
 import com.gu.support.workers.model.states.CreatePaymentMethodState
 import com.gu.zuora.encoding.CustomCodecs._
@@ -50,9 +50,8 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
     val maybeState = decode[CreatePaymentMethodState](createPayPalPaymentMethodContributionJson())
 
     val fieldsToTest = maybeState.map(state =>
-      (state.accessScope, state.product, state.paymentFields))
+      (state.product, state.paymentFields))
     fieldsToTest should be(Right(
-      AccessScopeNoRestriction,
       Contribution(5, GBP, Monthly),
       PayPalPaymentFields(validBaid)
     ))
@@ -62,9 +61,8 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
   it should "be able to decode a contribution with Stripe payment fields" in {
     val maybeState = decode[CreatePaymentMethodState](createStripePaymentMethodContributionJson())
     val fieldsToTest = maybeState.map(state =>
-      (state.accessScope, state.product, state.paymentFields))
+      (state.product, state.paymentFields))
     fieldsToTest should be(Right(
-      AccessScopeBySessionId(SessionId("testingToken")),
       Contribution(5, GBP, Monthly),
       StripePaymentFields(stripeToken)
     ))

--- a/src/test/scala/com/gu/support/workers/lambdas/CreateZuoraSubscriptionStateDecoderSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/CreateZuoraSubscriptionStateDecoderSpec.scala
@@ -1,0 +1,51 @@
+package com.gu.support.workers.lambdas
+
+import com.gu.i18n.Currency.GBP
+import com.gu.support.workers.Fixtures._
+import com.gu.support.workers.encoding.StateCodecs._
+import com.gu.support.workers.model.AccountAccessScope._
+import com.gu.support.workers.model.states.CreateZuoraSubscriptionState
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.parser._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+class CreateZuoraSubscriptionStateDecoderSpec extends FlatSpec with Matchers with MockitoSugar with LazyLogging {
+
+  def json(hasSession: Boolean): String =
+    s"""{
+          $requestIdJson,
+          $userJson,
+          "product": ${contribution(currency = GBP)},
+          "paymentMethod": $payPalPaymentMethod,
+          "salesForceContact": {
+            "Id": "123",
+            "AccountId": "123"
+          }${
+      if (hasSession) """,
+          "sessionId": "testingToken""""
+      else ""
+    }
+        }"""
+
+  "CreateZuoraSubscriptionStateDecoder" should "be able to decode allowed access scope" in {
+    val maybeState = decode[CreateZuoraSubscriptionState](json(false))
+
+    val fieldsToTest = maybeState.map(state =>
+      state.accountAccessScope)
+    fieldsToTest should be(Right(
+      AuthenticatedAccess
+    ))
+
+  }
+
+  it should "be able to decode session access scope" in {
+    val maybeState = decode[CreateZuoraSubscriptionState](json(true))
+    val fieldsToTest = maybeState.map(state =>
+      state.accountAccessScope)
+    fieldsToTest should be(Right(
+      SessionAccess(SessionId("testingToken"))
+    ))
+  }
+
+}

--- a/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -103,7 +103,18 @@ object Fixtures {
 
   val date = new LocalDate(2017, 5, 4)
 
-  def account(currency: Currency = GBP, paymentGateway: PaymentGateway = StripeGatewayDefault) = Account(salesforceAccountId, currency, salesforceAccountId, salesforceId, identityId, paymentGateway)
+  def account(
+    currency: Currency = GBP,
+    paymentGateway: PaymentGateway = StripeGatewayDefault
+  ): Account = Account(
+    salesforceAccountId,
+    currency,
+    salesforceAccountId,
+    salesforceId,
+    identityId,
+    paymentGateway,
+    None
+  )
 
   val contactDetails = ContactDetails("Test-FirstName", "Test-LastName", "test@gu.com", Country.UK)
   val creditCardPaymentMethod = CreditCardReferenceTransaction(tokenId, secondTokenId, cardNumber, Some(Country.UK), 12, 22, "AmericanExpress")
@@ -124,9 +135,15 @@ object Fixtures {
     Subscription(date, date, date)
   )
 
-  def creditCardSubscriptionRequest(currency: Currency = GBP) = SubscribeRequest(List(SubscribeItem(account(currency), contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())))
+  def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =
+    SubscribeRequest(List(
+      SubscribeItem(account(currency), contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())
+    ))
 
-  def directDebitSubscriptionRequest = SubscribeRequest(List(SubscribeItem(account(paymentGateway = DirectDebitGateway), contactDetails, directDebitPaymentMethod, monthlySubscriptionData, SubscribeOptions())))
+  def directDebitSubscriptionRequest: SubscribeRequest =
+    SubscribeRequest(List(
+      SubscribeItem(account(paymentGateway = DirectDebitGateway), contactDetails, directDebitPaymentMethod, monthlySubscriptionData, SubscribeOptions())
+    ))
 
   val invalidMonthlySubsData = SubscriptionData(
     List(

--- a/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -7,7 +7,7 @@ import com.gu.monitoring.SafeLogger._
 import com.gu.okhttp.RequestRunners
 import com.gu.support.workers.GetRecurringSubscription
 import com.gu.support.workers.lambdas.IdentityId
-import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
+import com.gu.support.workers.model.AccountAccessScope.{SessionAccess, AuthenticatedAccess, SessionId}
 import com.gu.support.workers.model.Monthly
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
@@ -52,25 +52,25 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "be able to find a monthly recurring subscription" in {
-    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("30001758").get, Monthly).map {
+    GetRecurringSubscription(uatService, AuthenticatedAccess, IdentityId("30001758").get, Monthly).map {
       _.flatMap(_.ratePlans.headOption.map(_.productName)) should be(Some("Contributor"))
     }
   }
 
   it should "ignore a monthly recurring subscription with wrong session id" in {
-    GetRecurringSubscription(uatService, AccessScopeBySessionId(SessionId("testZuora")), IdentityId("30001758").get, Monthly).map {
+    GetRecurringSubscription(uatService, SessionAccess(SessionId("testZuora")), IdentityId("30001758").get, Monthly).map {
       _.flatMap(_.ratePlans.headOption) should be(None)
     }
   }
 
   it should "ignore active subscriptions which do not have a recurring contributor plan" in {
-    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("18390845").get, Monthly).map {
+    GetRecurringSubscription(uatService, AuthenticatedAccess, IdentityId("18390845").get, Monthly).map {
       _ should be(None)
     }
   }
 
   it should "ignore cancelled recurring contributions" in {
-    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("30001780").get, Monthly).map {
+    GetRecurringSubscription(uatService, AuthenticatedAccess, IdentityId("30001780").get, Monthly).map {
       _ should be(None)
     }
   }

--- a/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -5,9 +5,13 @@ import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.okhttp.RequestRunners
+import com.gu.support.workers.GetRecurringSubscription
+import com.gu.support.workers.lambdas.IdentityId
+import com.gu.support.workers.model.AccessScope.{AccessScopeBySessionId, AccessScopeNoRestriction, SessionId}
 import com.gu.support.workers.model.Monthly
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.Fixtures._
+import com.gu.zuora.GetAccountForIdentity.ZuoraAccountNumber
 import com.gu.zuora.model.SubscribeRequest
 import com.gu.zuora.model.response.ZuoraErrorResponse
 import org.scalatest.{AsyncFlatSpec, Matchers}
@@ -28,18 +32,19 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "retrieve account ids from an Identity id" in {
-    uatService.getAccountIds("30001758").map {
+    uatService.getAccountFields(IdentityId("30001758").get).map {
       response =>
         response.nonEmpty should be(true)
     }
   }
 
   it should "be resistant to 'ZOQL injection'" in {
-    a[NumberFormatException] should be thrownBy uatService.getAccountIds("30000701' or status = 'Active")
+    // try https://github.com/guardian/zuora-auto-cancel/blob/master/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+    IdentityId("30000701' or status = 'Active") should be(None)
   }
 
   it should "retrieve subscriptions from an account id" in {
-    uatService.getSubscriptions("A00071408").map {
+    uatService.getSubscriptions(ZuoraAccountNumber("A00071408")).map {
       response =>
         response.nonEmpty should be(true)
         response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).monthlyContribution.productRatePlanId)
@@ -47,24 +52,26 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "be able to find a monthly recurring subscription" in {
-    uatService.getRecurringSubscription("30001758", Monthly).map {
-      response =>
-        response.isDefined should be(true)
-        response.get.ratePlans.head.productName should be("Contributor")
+    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("30001758").get, Monthly).map {
+      _.flatMap(_.ratePlans.headOption.map(_.productName)) should be(Some("Contributor"))
+    }
+  }
+
+  it should "ignore a monthly recurring subscription with wrong session id" in {
+    GetRecurringSubscription(uatService, AccessScopeBySessionId(SessionId("testZuora")), IdentityId("30001758").get, Monthly).map {
+      _.flatMap(_.ratePlans.headOption) should be(None)
     }
   }
 
   it should "ignore active subscriptions which do not have a recurring contributor plan" in {
-    uatService.getRecurringSubscription("18390845", Monthly).map {
-      response =>
-        response.isDefined should be(false)
+    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("18390845").get, Monthly).map {
+      _ should be(None)
     }
   }
 
   it should "ignore cancelled recurring contributions" in {
-    uatService.getRecurringSubscription("30001780", Monthly).map {
-      response =>
-        response.isDefined should be(false)
+    GetRecurringSubscription(uatService, AccessScopeNoRestriction, IdentityId("30001780").get, Monthly).map {
+      _ should be(None)
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

This PR is part of the series designed to deduplicate zuora subscriptions in case of browser side or step function repetitions.  I have already changed the models https://github.com/guardian/support-models/pull/43 and support frontend https://github.com/guardian/support-frontend/pull/1049

[**Trello Card**](https://trello.com/c/qaNYnBkp/87-npf-make-step-functions-check-form-visit-token-as-well-as-identity-id-for-preventing-duplicate-recurring-cont-from-the-same-page)

I have tested this in CODE but need to redo with the final approved code before shipping.