### PR TITLE
faster cpu to improve cold start time

### DIFF
--- a/cloud-formation/src/templates/lambda.yaml
+++ b/cloud-formation/src/templates/lambda.yaml
@@ -5,7 +5,7 @@
     {{> environmentVariables}}
     FunctionName: !Sub ${Stack}-{{name}}Lambda-${Stage}
     Handler: "com.gu.support.workers.lambdas.{{name}}::handleRequest"
-    MemorySize: {{memorySize}}{{^memorySize}}512{{/memorySize}}
+    MemorySize: {{memorySize}}{{^memorySize}}1536{{/memorySize}}
     Role: !GetAtt [ LambdaExecutionRole, Arn ]
     Code:
       S3Bucket: support-workers-dist


### PR DESCRIPTION
## Why are you doing this?

The lambda cold start time seems very slow.  The CPU allocation is related to the memory requested, so even though we need hardly any memory, we could increase the memory allocation in order to improve the cold starts.

I have increased from 0.5 to 1.5 gb because this is what the new product api has and it seems a lot quicker https://github.com/guardian/zuora-auto-cancel/blob/master/handlers/new-product-api/cfn.yaml#L122