### PR TITLE
make the test names and descriptions sensible

### DIFF
--- a/src/test/scala/com/gu/support/workers/AccountAccessScopeCodecTest.scala
+++ b/src/test/scala/com/gu/support/workers/AccountAccessScopeCodecTest.scala
@@ -6,12 +6,12 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class AccountAccessScopeCodecTest extends FlatSpec with Matchers {
 
-  it should "for backwards compatibility, deserialise when it's not specified to no restriction" in {
+  it should "understand that no session id means the identity user is authenticated" in {
     val actual = AccountAccessScope.fromInput(None)
     actual should be(AuthenticatedAccess)
   }
 
-  it should "deserialise when it's got a value to token scope" in {
+  it should "where a session id is specified, allow access by that session id" in {
     val actual = AccountAccessScope.fromInput(Some("hello"))
     actual should be(SessionAccess(SessionId("hello")))
   }

--- a/src/test/scala/com/gu/support/workers/IsAccountAccessAllowedSpec.scala
+++ b/src/test/scala/com/gu/support/workers/IsAccountAccessAllowedSpec.scala
@@ -4,13 +4,13 @@ import com.gu.support.workers.model.AccountAccessScope.{SessionAccess, Authentic
 import com.gu.zuora.GetAccountForIdentity.{CreatedInSession, NotCreatedInSession}
 import org.scalatest.{FlatSpec, Matchers}
 
-class GetRecurringSubscriptionIsInAccountAccessScopeSpec extends FlatSpec with Matchers {
+class IsAccountAccessAllowedSpec extends FlatSpec with Matchers {
 
-  it should "allow access to unlabelled accounts where there is no restriction" in {
+  it should "allow access to unlabelled accounts when we have authenticated access" in {
     IsAccountAccessAllowed(AuthenticatedAccess, NotCreatedInSession) should be(true)
   }
 
-  it should "allow access to labelled accounts where there is no restriction" in {
+  it should "allow access to labelled accounts when we have authenticated access" in {
     IsAccountAccessAllowed(AuthenticatedAccess, CreatedInSession(SessionId("existing"))) should be(true)
   }
 

--- a/src/test/scala/com/gu/support/workers/lambdas/CreateZuoraSubscriptionStateDecoderSpec.scala
+++ b/src/test/scala/com/gu/support/workers/lambdas/CreateZuoraSubscriptionStateDecoderSpec.scala
@@ -28,7 +28,7 @@ class CreateZuoraSubscriptionStateDecoderSpec extends FlatSpec with Matchers wit
     }
         }"""
 
-  "CreateZuoraSubscriptionStateDecoder" should "be able to decode allowed access scope" in {
+  "CreateZuoraSubscriptionStateDecoder" should "be able to decode authenticated access scope" in {
     val maybeState = decode[CreateZuoraSubscriptionState](json(false))
 
     val fieldsToTest = maybeState.map(state =>


### PR DESCRIPTION
## Why are you doing this?

@rupertbates [pointed out](https://github.com/guardian/support-workers/pull/147#pullrequestreview-168026962) that in my haste to fix the names of everything, I didn't check over the tests properly.  This PR sorts that out hopefully.
