### PR TITLE
Generate a GA id if not provided

### DIFF
--- a/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -1,5 +1,7 @@
 package com.gu.support.workers.lambdas
 
+import java.util.UUID
+
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.model.{GAData, OphanIds}
@@ -55,7 +57,7 @@ object SendAcquisitionEvent {
           acquisitionData <- Either.fromOption(a.acquisitionData, "acquisition data not included")
           ref = acquisitionData.referrerAcquisitionData
           hostname <- Either.fromOption(ref.hostname, "missing hostname in referrer acquisition data")
-          gaClientId <- Either.fromOption(ref.gaClientId, "missing gaClientId in referrer acquisition data")
+          gaClientId = ref.gaClientId.getOrElse(UUID.randomUUID().toString)
           ipAddress = ref.ipAddress
           userAgent = ref.userAgent
         } yield GAData(


### PR DESCRIPTION
## Why are you doing this?
The GA id is mandatory but may not be provided by support-frontend. If not then generate one (as in [subscriptions-frontend](https://github.com/guardian/subscriptions-frontend/blob/bd9c63ea44330f05ca82afd774343fedb6cd3655/app/controllers/Checkout.scala#L304))

