### PR TITLE
use stripe instead of paypal for testing zuora subscribe call

### DIFF
--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -45,6 +45,20 @@ object Fixtures {
          }
        """
 
+  val stripePaymentMethod = // test env card and cus token, not prod ones
+    s"""
+        {
+           "TokenId": "card_E0zitFfsO2wTEn",
+           "SecondTokenId": "cus_E0zic0cedDT5MZ",
+           "CreditCardNumber": "4242",
+           "CreditCardCountry": "US",
+           "CreditCardExpirationMonth": 2,
+           "CreditCardExpirationYear": 2022,
+           "CreditCardType": "Visa",
+           "Type": "CreditCardReferenceTransaction"
+         }
+       """
+
   def contribution(amount: BigDecimal = 5, currency: Currency = GBP, billingPeriod: BillingPeriod = Monthly) =
     s"""
       {
@@ -180,7 +194,7 @@ object Fixtures {
        |  $requestIdJson,
        |  $userJson,
        |  "product": ${product},
-       |  "paymentMethod": $payPalPaymentMethod,
+       |  "paymentMethod": $stripePaymentMethod,
        |  "salesForceContact": {
        |    "Id": "123",
        |    "AccountId": "123"
@@ -203,7 +217,7 @@ object Fixtures {
             $requestIdJson,
             $userJson,
             "product": ${contribution(billingPeriod = billingPeriod)},
-            "paymentMethod": $payPalPaymentMethod,
+            "paymentMethod": $stripePaymentMethod,
             "salesForceContact": $salesforceContactJson
             }
         """
@@ -213,7 +227,7 @@ object Fixtures {
             $requestIdJson,
             $userJson,
             "product": ${digitalPackJson},
-            "paymentMethod": $payPalPaymentMethod,
+            "paymentMethod": $stripePaymentMethod,
             "salesForceContact": $salesforceContactJson
             }
         """
@@ -355,7 +369,7 @@ object Fixtures {
           $requestIdJson,
           $userJson,
           "product": ${contribution(currency = GBP)},
-          "paymentMethod": $payPalPaymentMethod,
+          "paymentMethod": $stripePaymentMethod,
           "acquisitionData": $acquisitionData
         }"""
   )


### PR DESCRIPTION
## Why are you doing this?
because we have zuora dev and uat, but they both use invoice ids from the same set.  The id is used when charging the person as a unique reference.  uat is well ahead of dev, so when we run the tests in dev, if the coresponding invoive in uat was paypal, it will fail and complain we already used it.

## Changes
this pr changes to use stripe, which has no such problem,  I just used a test card and customer which should hopefully be OK.
@rupertbates 