### PR TITLE
Use abTests in ReferrerAcquisitionData

### DIFF
--- a/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -101,7 +101,11 @@ object SendAcquisitionEvent {
               // Currently only passing through at most one campaign code
               campaignCode = data.referrerAcquisitionData.campaignCode.map(Set(_)),
               abTests = Some(thrift.AbTestInfo(
-                data.supportAbTests ++ Set(data.referrerAcquisitionData.abTest).flatten
+                data.supportAbTests
+                  // abTest is deprecated and support-frontend now sends abTests.
+                  // but let's add abTest as well just in case.
+                  ++ data.referrerAcquisitionData.abTests.getOrElse(Set())
+                  ++ Set(data.referrerAcquisitionData.abTest).flatten
               )),
               countryCode = Some(state.user.country.alpha2),
               referrerPageViewId = data.referrerAcquisitionData.referrerPageviewId,


### PR DESCRIPTION
Supposedly, `abTest` is deprecated and `abTests` is the one we should be using (according to [this comment](https://github.com/guardian/acquisition-event-producer/blob/91ff314c2f22eac82f1e7594cee6a300e6681873/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala#L19)).

@Ap0c followed this advice in https://github.com/guardian/support-frontend/pull/997 when he changed the clientside model from `abTest: ?AcquisitionABTest` to `abTests: ?AcquisitionABTest[]`. But unfortunately there's a bit in the middle here in support-workers which was only looking at `abTest`.

This is why we haven't been getting A/B test data for recurring contributions for the last few months. (We've had component ids as a workaround, which is why we didn't prioritise fixing it til now)

@Mullefa can you remember what the story is with that deprecation? It would be nice to remove the deprecated `abTest` field everywhere, but I seem to remember that Thrift's position-sensitive data encoding strategy makes that problematic.