### PR TITLE
Send acquisition events to kinesis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.39",
+      "com.gu" %% "support-models" % "0.40",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
@@ -63,6 +63,7 @@ lazy val root = (project in file("."))
       // This is required to force aws libraries to use the latest version of jackson
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7",
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.7",
       "org.scalatest" %% "scalatest" % "3.0.5" % "it,test",
       "org.mockito" % "mockito-core" % "1.9.5" % "it,test",
       "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % "it,test",

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.40",
+      "com.gu" %% "support-models" % "0.41",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -16,6 +16,9 @@ Parameters:
   OphanRole:
     Type: String
     Description: ARN of the Ophan cross-account role
+  KinesisStreamArn:
+    Type: String
+    Description: ARN of the kinesis stream to write events to
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
@@ -85,6 +88,13 @@ Resources:
               Action: sts:AssumeRole
               Resource:
                 Ref: OphanRole
+        - PolicyName: Kinesis
+          PolicyDocument:
+            Statement:
+            - Effect: Allow
+              Action: kinesis:*
+              Resource:
+                Ref: KinesisStreamArn
 
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/cloud-formation/src/templates/cfn-template.yaml
+++ b/cloud-formation/src/templates/cfn-template.yaml
@@ -18,7 +18,7 @@ Parameters:
     Description: ARN of the Ophan cross-account role
   KinesisStreamArn:
     Type: String
-    Description: ARN of the kinesis stream to write events to
+    Description: ARN of the kinesis stream to write acquisition events to
 Conditions:
   CreateProdResources: !Equals [!Ref "Stage", "PROD"]
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]

--- a/src/main/scala/com/gu/config/Configuration.scala
+++ b/src/main/scala/com/gu/config/Configuration.scala
@@ -31,4 +31,6 @@ object Configuration {
   val promotionsConfigProvider = new PromotionsConfigProvider(config, stage)
 
   val contributionThanksQueueName = config.getString("email.thankYou.queueName")
+
+  val kinesisStreamName = config.getString("kinesis.streamName")
 }

--- a/src/main/scala/com/gu/ophan/AcquisitionService.scala
+++ b/src/main/scala/com/gu/ophan/AcquisitionService.scala
@@ -1,7 +1,6 @@
 package com.gu.ophan
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
-import com.gu.acquisition.services.DefaultAcquisitionServiceConfig
+import com.gu.acquisition.services.LambdaConfig
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
 
@@ -12,12 +11,7 @@ object AcquisitionService {
       com.gu.acquisition.services.MockAcquisitionService
     } else {
 
-      val credentialsProvider = new AWSCredentialsProviderChain(
-        InstanceProfileCredentialsProvider.getInstance()
-      )
-
-      val config = DefaultAcquisitionServiceConfig(
-        credentialsProvider,
+      val config = LambdaConfig(
         kinesisStreamName = Configuration.kinesisStreamName
       )
       com.gu.acquisition.services.AcquisitionService.prod(config)(RequestRunners.client)

--- a/src/main/scala/com/gu/ophan/AcquisitionService.scala
+++ b/src/main/scala/com/gu/ophan/AcquisitionService.scala
@@ -1,5 +1,9 @@
 package com.gu.ophan
 
+import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.gu.acquisition.services.DefaultAcquisitionServiceConfig
+import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
 
 object AcquisitionService {
@@ -8,6 +12,16 @@ object AcquisitionService {
     if (isTestService) {
       com.gu.acquisition.services.MockAcquisitionService
     } else {
-      com.gu.acquisition.services.AcquisitionService.prod(RequestRunners.client)
+
+      val credentialsProvider = new AWSCredentialsProviderChain(
+        new ProfileCredentialsProvider("membership"),
+        InstanceProfileCredentialsProvider.getInstance()
+      )
+
+      val config = DefaultAcquisitionServiceConfig(
+        credentialsProvider,
+        kinesisStreamName = Configuration.kinesisStreamName
+      )
+      com.gu.acquisition.services.AcquisitionService.prod(config)(RequestRunners.client)
     }
 }

--- a/src/main/scala/com/gu/ophan/AcquisitionService.scala
+++ b/src/main/scala/com/gu/ophan/AcquisitionService.scala
@@ -1,7 +1,6 @@
 package com.gu.ophan
 
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.gu.acquisition.services.DefaultAcquisitionServiceConfig
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
@@ -14,7 +13,6 @@ object AcquisitionService {
     } else {
 
       val credentialsProvider = new AWSCredentialsProviderChain(
-        new ProfileCredentialsProvider("membership"),
         InstanceProfileCredentialsProvider.getInstance()
       )
 

--- a/src/main/scala/com/gu/ophan/AcquisitionService.scala
+++ b/src/main/scala/com/gu/ophan/AcquisitionService.scala
@@ -1,8 +1,11 @@
 package com.gu.ophan
 
-import com.gu.acquisition.services.LambdaConfig
+import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.gu.acquisition.services.{DefaultAcquisitionServiceConfig, Ec2OrLocalConfig, LambdaConfig}
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners
+import com.gu.support.config.Stages
 
 object AcquisitionService {
 
@@ -11,9 +14,18 @@ object AcquisitionService {
       com.gu.acquisition.services.MockAcquisitionService
     } else {
 
-      val config = LambdaConfig(
-        kinesisStreamName = Configuration.kinesisStreamName
-      )
+      //Credentials provider is only required if running locally
+      val config: DefaultAcquisitionServiceConfig = {
+        if (Configuration.stage == Stages.DEV) {
+          val credentialsProvider = new AWSCredentialsProviderChain(
+            new ProfileCredentialsProvider("membership"),
+            InstanceProfileCredentialsProvider.getInstance()
+          )
+
+          Ec2OrLocalConfig(credentialsProvider, Configuration.kinesisStreamName)
+        } else LambdaConfig(Configuration.kinesisStreamName)
+      }
+
       com.gu.acquisition.services.AcquisitionService.prod(config)(RequestRunners.client)
     }
 }

--- a/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -52,6 +52,7 @@ object RetryImplicits {
         case BuildError(message) => new RetryNone(message)
         case _: NetworkFailure => new RetryUnlimited(error.getMessage, error)
         case _: ResponseUnsuccessful => new RetryLimited(error.getMessage, error)
+        case kinesisError: KinesisError => new RetryNone(kinesisError.getMessage)
       }
   }
 }


### PR DESCRIPTION
## Why are you doing this?
Adds a third acquisition service (in addition to ophan and GA) - a kinesis stream.
This will initially be used for the contributions ticker calculation.

Note - a credentials provider is not required by the kinesis client if running in a lambda. But it is required in order to run the integration tests locally.