### PR TITLE
Bump support-models and remove abTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.39",
+      "com.gu" %% "support-models" % "0.42",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -101,11 +101,7 @@ object SendAcquisitionEvent {
               // Currently only passing through at most one campaign code
               campaignCode = data.referrerAcquisitionData.campaignCode.map(Set(_)),
               abTests = Some(thrift.AbTestInfo(
-                data.supportAbTests
-                  // abTest is deprecated and support-frontend now sends abTests.
-                  // but let's add abTest as well just in case.
-                  ++ data.referrerAcquisitionData.abTests.getOrElse(Set())
-                  ++ Set(data.referrerAcquisitionData.abTest).flatten
+                data.supportAbTests ++ data.referrerAcquisitionData.abTests.getOrElse(Set())
               )),
               countryCode = Some(state.user.country.alpha2),
               referrerPageViewId = data.referrerAcquisitionData.referrerPageviewId,


### PR DESCRIPTION
That version of `support-model` uses a version of `aacquisition-event-producer` that removes the deprecated `abTest` field

https://github.com/guardian/support-libraries/pull/5
https://github.com/guardian/acquisition-event-producer/pull/43