### PR TITLE
Set region in code

### DIFF
--- a/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
+++ b/src/main/scala/com/gu/support/workers/encoding/Encryption.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.encoding
 
 import java.nio.ByteBuffer
 
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.kms.AWSKMSClientBuilder
 import com.amazonaws.services.kms.model._
 import com.gu.aws.CredentialsProvider
@@ -33,6 +34,7 @@ class AwsEncryptionProvider(encryptionKeyId: String) extends EncryptionProvider 
   private val kms = AWSKMSClientBuilder
     .standard()
     .withCredentials(CredentialsProvider)
+    .withRegion(Regions.EU_WEST_1)
     .build()
 
   override def encrypt(data: String): Array[Byte] = {


### PR DESCRIPTION
So you don't need the region set in your environment (as an environment variable or in `~/.aws/config`)

This means integration tests will work locally without an `~/.aws/config` file