### PR TITLE
Remove A/B test from test fixture

### DIFF
--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -103,7 +103,6 @@ object Fixtures {
           "componentId":null,
           "componentType":null,
           "source":null,
-          "abTest":null,
           "abTests":[{
             "name":"fakeTest",
             "variant":"fakeVariant"


### PR DESCRIPTION
Weirdly didn't seem to affect any tests. But it should go.