### PR TITLE
Replace account number with subscription number in thank you email

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.42",
+      "com.gu" %% "support-models" % "0.45-SNAPSHOT",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.45-SNAPSHOT",
+      "com.gu" %% "support-models" % "0.45",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -37,7 +37,7 @@ import org.joda.time.DateTime
 //}
 
 case class DigitalPackEmailFields(
-    accountId: String,
+    subscriptionNumber: String,
     billingPeriod: BillingPeriod,
     user: User,
     currency: Currency,
@@ -61,7 +61,7 @@ case class DigitalPackEmailFields(
   }
 
   override val fields = List(
-    "ZuoraSubscriberId" -> accountId,
+    "ZuoraSubscriberId" -> subscriptionNumber,
     "SubscriberKey" -> user.primaryEmailAddress,
     "EmailAddress" -> user.primaryEmailAddress,
     "Subscription term" -> billingPeriod.noun,

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -56,7 +56,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           directDebitMandateId = directDebitMandateId
         )
         case d: DigitalPack => DigitalPackEmailFields(
-          accountId = state.accountNumber,
+          subscriptionNumber = state.subscriptionNumber,
           billingPeriod = d.billingPeriod,
           user = state.user,
           currency = d.currency,

--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -190,6 +190,7 @@ object Fixtures {
        |    "Id": "sfContactId123",
        |    "AccountId": "sfAccountId321"
        |  },
+       |  "accountNumber": "A-00123",
        |  "subscriptionNumber": "A-S12345678"
        |}
      """.stripMargin

--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -187,10 +187,10 @@ object Fixtures {
        |  "product": ${product},
        |  "paymentMethod": $stripePaymentMethod,
        |  "salesForceContact": {
-       |    "Id": "123",
-       |    "AccountId": "123"
+       |    "Id": "sfContactId123",
+       |    "AccountId": "sfAccountId321"
        |  },
-       |  "accountNumber": "123"
+       |  "subscriptionNumber": "A-S12345678"
        |}
      """.stripMargin
 

--- a/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -37,7 +37,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createZuora.handleRequest(in, outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
-    sendThankYouEmail._1.accountNumber.length should be > 0
+    sendThankYouEmail._1.subscriptionNumber.length should be > 0
   }
 
   "CreateZuoraSubscription lambda" should "create an annual Zuora subscription" in {
@@ -48,7 +48,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createZuora.handleRequest(wrapFixture(createContributionZuoraSubscriptionJson(billingPeriod = Annual)), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
-    sendThankYouEmail._1.accountNumber.length should be > 0
+    sendThankYouEmail._1.subscriptionNumber.length should be > 0
   }
 
   "CreateZuoraSubscription lambda" should "create a Digital Pack subscription" in {
@@ -59,7 +59,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createZuora.handleRequest(wrapFixture(createDigiPackZuoraSubscriptionJson), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
-    sendThankYouEmail._1.accountNumber.length should be > 0
+    sendThankYouEmail._1.subscriptionNumber.length should be > 0
   }
 
   it should "create a Digital Pack subscription with a discount" in {
@@ -70,7 +70,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createZuora.handleRequest(wrapFixture(createDigiPackSubscriptionWithPromoJson), outStream, context)
 
     val sendThankYouEmail = Encoding.in[SendThankYouEmailState](outStream.toInputStream).get
-    sendThankYouEmail._1.accountNumber.length should be > 0
+    sendThankYouEmail._1.subscriptionNumber.length should be > 0
   }
 
   val realZuoraService = new ZuoraService(zuoraConfigProvider.get(false), configurableFutureRunner(60.seconds))

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -45,7 +45,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Monthly, SfContactId("sfContactId"), dd, Some(mandateId)
+      "UK", "", Monthly, SfContactId("0036E00000WK8fDQAT"), dd, Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -63,7 +63,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       user,
       GBP,
       dd,
-      SfContactId("sfContactId"),
+      SfContactId("0036E00000WK8fDQAT"),
       Some(mandateId)
     )
     val service = new EmailService


### PR DESCRIPTION
## Why are you doing this?

The current Digital Pack thank you emails (triggered from subscriptions-frontend) include the Zuora subscription number, but the versions of the email triggered via support-workers include the Zuora account number.

Longer term, I think it is worth revisiting whether we should be including any Zuora numbers/ids at all (since we want users to redeem their digital benefits via their identity account), but this PR preserves the existing behaviour for now.

[**Trello Card**](https://trello.com/c/BdMnVPuz/1811-thank-you-email-credit-debit-card)

Note that this PR relies on a support-models release.

## Changes

* Use a new version of support-models
* Pass subscription number into emails (instead of account number)

