### PR TITLE
Preview upcoming payments and pass information through to thank you email lambda

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.45",
+      "com.gu" %% "support-models" % "0.46-SNAPSHOT",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.47",
+      "com.gu" %% "support-models" % "0.48",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.46-SNAPSHOT",
+      "com.gu" %% "support-models" % "0.47",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -1,0 +1,39 @@
+package com.gu.support.workers
+
+import com.gu.services.Services
+import com.gu.support.zuora.api.response.{Charge, PreviewSubscribeResponse}
+import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeItem}
+import org.joda.time.LocalDate
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object PreviewPaymentSchedule {
+
+  def apply(
+    subscribeItem: SubscribeItem,
+    billingPeriod: BillingPeriod,
+    services: Services,
+    singleResponseCheck: Future[List[PreviewSubscribeResponse]] => Future[PreviewSubscribeResponse]
+  ): Future[PaymentSchedule] = {
+    val numberOfInvoicesToPreview: Int = billingPeriod match {
+      case Monthly => 13
+      case Quarterly => 5
+      case com.gu.support.workers.Annual => 2
+    }
+    singleResponseCheck(
+      services.zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview))
+    ).map(response => paymentSchedule(response.invoiceData.flatMap(_.invoiceItem)))
+  }
+
+  def paymentSchedule(charges: List[Charge]): PaymentSchedule = {
+    val dateChargeMap = charges.groupBy(_.serviceStartDate)
+    val payments = dateChargeMap.map { dateAndCharge =>
+      val (paymentDate, charges) = dateAndCharge
+      Payment(paymentDate, charges.map(charge => charge.chargeAmount + charge.taxAmount).sum)
+    }
+    implicit def localDateOrdering: Ordering[LocalDate] = Ordering.fromLessThan(_ isBefore _)
+    PaymentSchedule(payments.toList.sortBy(_.date))
+  }
+
+}

--- a/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -20,6 +20,7 @@ object PreviewPaymentSchedule {
       case Monthly => 13
       case Quarterly => 5
       case com.gu.support.workers.Annual => 2
+      case SixWeekly => 2
     }
     singleResponseCheck(
       services.zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview))

--- a/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -7,7 +7,7 @@ import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.support.config.ZuoraConfig
 import com.gu.support.workers.IdentityId
 import com.gu.support.zuora.api.response._
-import com.gu.support.zuora.api.{QueryData, SubscribeRequest}
+import com.gu.support.zuora.api.{PreviewSubscribeRequest, QueryData, SubscribeRequest}
 import com.gu.support.zuora.domain.{DomainAccount, DomainSubscription}
 import io.circe
 import io.circe.Decoder
@@ -39,6 +39,9 @@ class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: O
     get[SubscriptionsResponse](s"subscriptions/accounts/${accountNumber.value}", authHeaders).map { subscriptionsResponse =>
       subscriptionsResponse.subscriptions.map(DomainSubscription.fromSubscription)
     }
+
+  def previewSubscribe(previewSubscribeRequest: PreviewSubscribeRequest): Future[List[PreviewSubscribeResponse]] =
+    postJson[List[PreviewSubscribeResponse]]("action/subscribe", previewSubscribeRequest.asJson, authHeaders)
 
   def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
     postJson[List[SubscribeResponseAccount]]("action/subscribe", subscribeRequest.asJson, authHeaders)

--- a/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -191,7 +191,23 @@ object Fixtures {
        |    "AccountId": "sfAccountId321"
        |  },
        |  "accountNumber": "A-00123",
-       |  "subscriptionNumber": "A-S12345678"
+       |  "subscriptionNumber": "A-S12345678",
+       |  "paymentSchedule": {
+       |    "payments": [
+       |      {
+       |        "date": "2019-01-14",
+       |        "amount": 11.99
+       |      },
+       |      {
+       |        "date": "2019-02-14",
+       |        "amount": 11.99
+       |      },
+       |      {
+       |        "date": "2019-03-14",
+       |        "amount": 11.99
+       |      }
+       |    ]
+       |  }
        |}
      """.stripMargin
 

--- a/src/test/scala/com/gu/support/workers/PreviewPaymentScheduleSpec.scala
+++ b/src/test/scala/com/gu/support/workers/PreviewPaymentScheduleSpec.scala
@@ -1,0 +1,32 @@
+package com.gu.support.workers
+
+import com.gu.support.zuora.api.response.Charge
+import org.joda.time.LocalDate
+import org.scalatest.{FlatSpec, Matchers}
+
+class PreviewPaymentScheduleSpec extends FlatSpec with Matchers {
+
+  val firstPaymentDate = new LocalDate(2019, 1, 14)
+
+  "paymentSchedule" should "calculate a payment schedule correctly for products without tax" in {
+    val taxExclusiveCharge = Charge(firstPaymentDate, firstPaymentDate.plusMonths(1), 0, 5.00)
+    val charges = List(
+      taxExclusiveCharge,
+      taxExclusiveCharge.copy(serviceStartDate = firstPaymentDate.plusMonths(1), serviceEndDate = firstPaymentDate.plusMonths(2))
+    )
+    val expected = PaymentSchedule(List(Payment(firstPaymentDate, 5.00), Payment(firstPaymentDate.plusMonths(1), 5.00)))
+    val schedule = PreviewPaymentSchedule.paymentSchedule(charges)
+    assert(schedule == expected)
+  }
+
+  "paymentSchedule" should "calculate a payment schedule correctly for products with tax" in {
+    val charges = List(
+      Charge(firstPaymentDate, firstPaymentDate.plusMonths(1), 1.25, 4.00),
+      Charge(firstPaymentDate.plusMonths(1), firstPaymentDate.plusMonths(2), 1.50, 5.00)
+    )
+    val expected = PaymentSchedule(List(Payment(firstPaymentDate, 5.25), Payment(firstPaymentDate.plusMonths(1), 6.50)))
+    val schedule = PreviewPaymentSchedule.paymentSchedule(charges)
+    assert(schedule == expected)
+  }
+
+}

--- a/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -13,7 +13,7 @@ import com.gu.support.workers.errors.MockServicesCreator
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.states.SendThankYouEmailState
 import com.gu.support.workers.{Annual, IdentityId, LambdaSpec, Monthly}
-import com.gu.support.zuora.api.SubscribeRequest
+import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
 import com.gu.support.zuora.api.response.ZuoraAccountNumber
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.ZuoraService
@@ -86,6 +86,8 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
       .thenReturn(Future.successful(Nil))
     when(mockZuora.getSubscriptions(any[ZuoraAccountNumber]))
       .thenReturn(Future.successful(Nil))
+    when(mockZuora.previewSubscribe(any[PreviewSubscribeRequest]))
+      .thenAnswer((invocation: InvocationOnMock) => realZuoraService.previewSubscribe(invocation.getArguments.head.asInstanceOf[PreviewSubscribeRequest]))
     when(mockZuora.subscribe(any[SubscribeRequest]))
       .thenAnswer((invocation: InvocationOnMock) => realZuoraService.subscribe(invocation.getArguments.head.asInstanceOf[SubscribeRequest]))
     when(mockZuora.config).thenReturn(realZuoraService.config)

--- a/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -53,19 +53,6 @@ object Fixtures {
     Subscription(date, date, date)
   )
 
-  def previewRequest(currency: Currency = GBP): PreviewSubscribeRequest = PreviewSubscribeRequest(
-    List(
-      PreviewSubscribeItem(
-        account(currency),
-        contactDetails,
-        creditCardPaymentMethod,
-        monthlySubscriptionData,
-        SubscribeOptions(),
-        PreviewOptions(numberOfPeriods = 3)
-      )
-    )
-  )
-
   def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =
     SubscribeRequest(List(
       SubscribeItem(account(currency), contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())

--- a/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -53,6 +53,19 @@ object Fixtures {
     Subscription(date, date, date)
   )
 
+  def previewRequest(currency: Currency = GBP): PreviewSubscribeRequest = PreviewSubscribeRequest(
+    List(
+      PreviewSubscribeItem(
+        account(currency),
+        contactDetails,
+        creditCardPaymentMethod,
+        monthlySubscriptionData,
+        SubscribeOptions(),
+        PreviewOptions(numberOfPeriods = 3)
+      )
+    )
+  )
+
   def creditCardSubscriptionRequest(currency: Currency = GBP): SubscribeRequest =
     SubscribeRequest(List(
       SubscribeItem(account(currency), contactDetails, creditCardPaymentMethod, monthlySubscriptionData, SubscribeOptions())

--- a/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -114,7 +114,7 @@ class ZuoraSpec extends AsyncFlatSpec with Matchers {
     }
   }
 
-  "Preview request" should "succeed" in doRequest(Left(previewRequest(GBP)))
+  "Preview request" should "succeed" in doRequest(Left(PreviewSubscribeRequest.fromSubscribe(creditCardSubscriptionRequest(GBP).subscribes.head, 13)))
 
   "Subscribe request" should "succeed" in doRequest(Right(creditCardSubscriptionRequest(GBP)))
 


### PR DESCRIPTION
## Why are you doing this?

This PR allows us to preview a user's payment schedule before creating a new subscription. This will allow us to provide accurate billing information in thank you emails (for subscriptions products), which becomes more important in complex scenarios where promotions and discounts are involved. 

Note that the email updates which make use of this payment schedule will be added in a subsequent PR.

## Changes

* Use latest version of support-models and pass payment schedule through as part of SendThankYouEmailState
* Add code for previewing invoices via Zuora's REST API
* Refactor CreateZuoraSubscription slightly to accommodate preview
* Add (and update) unit tests