### PR TITLE
Use payment schedule to provide accurate pricing info in email

### DIFF
--- a/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -24,7 +24,7 @@ case class ContributionEmailFields(
       "account number" -> mask(dd.bankTransferAccountNumber),
       "sort code" -> hyphenate(dd.bankCode),
       "Mandate ID" -> directDebitMandateId.getOrElse(""),
-      "first payment date" -> formatDate(created.plusDays(10)),
+      "first payment date" -> formatDate(created.plusDays(10).toLocalDate),
       "payment method" -> "Direct Debit"
     )
     case _: PayPalReferenceTransaction => List("payment method" -> "PayPal")

--- a/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -1,6 +1,6 @@
 package com.gu.emailservices
 
-import org.joda.time.DateTime
+import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -38,6 +38,5 @@ trait EmailFields {
 
   protected def mask(s: String): String = s.replace(s.substring(0, 6), "******")
   protected def hyphenate(s: String): String = s"${s.substring(0, 2)}-${s.substring(2, 4)}-${s.substring(4, 6)}"
-  protected def formatPrice(price: BigDecimal): String = price.bigDecimal.stripTrailingZeros.toPlainString
-  protected def formatDate(d: DateTime): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
+  protected def formatDate(d: LocalDate): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
 }

--- a/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -1,0 +1,43 @@
+package com.gu.emailservices
+
+import java.text.DecimalFormat
+import com.gu.i18n.Currency
+import com.gu.support.workers._
+import org.joda.time.{LocalDate, Months}
+
+object SubscriptionEmailFieldHelpers {
+
+  implicit def localDateOrdering: Ordering[LocalDate] = Ordering.fromLessThan(_ isBefore _)
+
+  val formatter = new DecimalFormat("#.00")
+
+  def formatPrice(price: Double): String = formatter.format(price)
+
+  def priceWithCurrency(currency: Currency, amount: Double): String = s"${currency.glyph}${formatter.format(amount)}"
+
+  def firstPayment(paymentSchedule: PaymentSchedule): Payment = paymentSchedule.payments.minBy(_.date)
+
+  def describe(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency): String = {
+    val initialPrice = firstPayment(paymentSchedule).amount
+    val (paymentsWithInitialPrice, paymentsWithDifferentPrice) = paymentSchedule.payments.partition(_.amount == initialPrice)
+    if (paymentsWithDifferentPrice.isEmpty) {
+      s"${priceWithCurrency(currency, initialPrice)} every ${billingPeriod.noun}"
+    } else {
+      val introductoryTimespan = {
+        val firstIntroductoryPayment = paymentsWithInitialPrice.minBy(_.date)
+        val firstDifferentPayment = paymentsWithDifferentPrice.minBy(_.date)
+        val monthsAtIntroductoryPrice = Months.monthsBetween(firstIntroductoryPayment.date, firstDifferentPayment.date).getMonths
+        val introductoryBillingPeriods = billingPeriod match {
+          case Annual => monthsAtIntroductoryPrice / 12
+          case Quarterly => monthsAtIntroductoryPrice / 3
+          case Monthly => monthsAtIntroductoryPrice
+        }
+        val pluraliseIfRequired = if (introductoryBillingPeriods > 1) "s" else ""
+        s"$introductoryBillingPeriods ${billingPeriod.noun}$pluraliseIfRequired"
+      }
+      s"${priceWithCurrency(currency, initialPrice)} for $introductoryTimespan, " +
+        s"then ${priceWithCurrency(currency, paymentsWithDifferentPrice.head.amount)} every ${billingPeriod.noun}"
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -8,7 +8,7 @@ import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.states.SendThankYouEmailState
-import com.gu.support.workers.{Contribution, DigitalPack, DirectDebitPaymentMethod, RequestInfo}
+import com.gu.support.workers._
 import com.gu.threadpools.CustomPool.executionContext
 import com.gu.zuora.ZuoraService
 import io.circe.generic.auto._
@@ -59,6 +59,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           subscriptionNumber = state.subscriptionNumber,
           billingPeriod = d.billingPeriod,
           user = state.user,
+          paymentSchedule = state.paymentSchedule,
           currency = d.currency,
           paymentMethod = state.paymentMethod,
           directDebitMandateId = directDebitMandateId,

--- a/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -1,0 +1,62 @@
+package com.gu.emailservices
+
+import com.gu.i18n.Currency.{EUR, GBP, USD}
+import com.gu.support.workers.{Annual, Monthly, Payment, PaymentSchedule, Quarterly}
+import org.joda.time.LocalDate
+import org.scalatest.{FlatSpec, Matchers}
+
+class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
+
+  def payments(original: Payment, subsequentMonths: List[Int]): List[Payment] = {
+    val subsequentPayments = subsequentMonths.map {
+      monthNumber => original.copy(date = original.date.plusMonths(monthNumber))
+    }
+    List(original) ++ subsequentPayments
+  }
+
+  "describe" should "explain a simple annual payment schedule correctly" in {
+    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 119.90)
+    val schedule = payments(standardDigitalPackPayment, List(12))
+    val expected = "£119.90 every year"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Annual, GBP) == expected)
+  }
+
+  "describe" should "explain a simple quarterly payment schedule correctly" in {
+    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 57.50)
+    val schedule = payments(standardDigitalPackPayment, List(3, 6, 9))
+    val expected = "$57.50 every quarter"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, USD) == expected)
+  }
+
+  "describe" should "explain a simple monthly payment schedule correctly" in {
+    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 11.99)
+    val schedule = payments(standardDigitalPackPayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+    val expected = "€11.99 every month"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, EUR) == expected)
+  }
+
+  "describe" should "explain a payment schedule correctly if the first year is discounted" in {
+    val discountedDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 100.90)
+    val standardDigitalPackPayment = Payment(new LocalDate(2020, 1, 14), 119.90)
+    val schedule = PaymentSchedule(List(discountedDigitalPackPayment, standardDigitalPackPayment))
+    val expected = "£100.90 for 1 year, then £119.90 every year"
+    assert(SubscriptionEmailFieldHelpers.describe(schedule, Annual, GBP) == expected)
+  }
+
+  "describe" should "explain a payment schedule correctly if the first 3 months are discounted" in {
+    val firstDiscountedPayment = Payment(new LocalDate(2019, 1, 14), 5.99)
+    val firstFullPricePayment = Payment(new LocalDate(2019, 4, 14), 11.99)
+    val schedule: List[Payment] = payments(firstDiscountedPayment, List(1, 2)) ++ payments(firstFullPricePayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9))
+    val expected = "£5.99 for 3 months, then £11.99 every month"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP) == expected)
+  }
+
+  "describe" should "explain a payment schedule correctly if the first 2 quarters are discounted" in {
+    val firstDiscountedPayment = Payment(new LocalDate(2019, 1, 14), 30.00)
+    val firstFullPricePayment = Payment(new LocalDate(2019, 7, 14), 37.50)
+    val schedule: List[Payment] = payments(firstDiscountedPayment, List(3)) ++ payments(firstFullPricePayment, List(3, 6))
+    val expected = "£30.00 for 2 quarters, then £37.50 every quarter"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP) == expected)
+  }
+
+}

--- a/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -14,46 +14,48 @@ class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
     List(original) ++ subsequentPayments
   }
 
+  val referenceDate = new LocalDate(2019, 1, 14)
+
   "describe" should "explain a simple annual payment schedule correctly" in {
-    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 119.90)
+    val standardDigitalPackPayment = Payment(referenceDate, 119.90)
     val schedule = payments(standardDigitalPackPayment, List(12))
     val expected = "£119.90 every year"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Annual, GBP) == expected)
   }
 
   "describe" should "explain a simple quarterly payment schedule correctly" in {
-    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 57.50)
+    val standardDigitalPackPayment = Payment(referenceDate, 57.50)
     val schedule = payments(standardDigitalPackPayment, List(3, 6, 9))
     val expected = "$57.50 every quarter"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, USD) == expected)
   }
 
   "describe" should "explain a simple monthly payment schedule correctly" in {
-    val standardDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 11.99)
+    val standardDigitalPackPayment = Payment(referenceDate, 11.99)
     val schedule = payments(standardDigitalPackPayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
     val expected = "€11.99 every month"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, EUR) == expected)
   }
 
   "describe" should "explain a payment schedule correctly if the first year is discounted" in {
-    val discountedDigitalPackPayment = Payment(new LocalDate(2019, 1, 14), 100.90)
-    val standardDigitalPackPayment = Payment(new LocalDate(2020, 1, 14), 119.90)
+    val discountedDigitalPackPayment = Payment(referenceDate, 100.90)
+    val standardDigitalPackPayment = Payment(referenceDate.plusYears(1), 119.90)
     val schedule = PaymentSchedule(List(discountedDigitalPackPayment, standardDigitalPackPayment))
     val expected = "£100.90 for 1 year, then £119.90 every year"
     assert(SubscriptionEmailFieldHelpers.describe(schedule, Annual, GBP) == expected)
   }
 
   "describe" should "explain a payment schedule correctly if the first 3 months are discounted" in {
-    val firstDiscountedPayment = Payment(new LocalDate(2019, 1, 14), 5.99)
-    val firstFullPricePayment = Payment(new LocalDate(2019, 4, 14), 11.99)
+    val firstDiscountedPayment = Payment(referenceDate, 5.99)
+    val firstFullPricePayment = Payment(referenceDate.plusMonths(3), 11.99)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(1, 2)) ++ payments(firstFullPricePayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9))
     val expected = "£5.99 for 3 months, then £11.99 every month"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP) == expected)
   }
 
   "describe" should "explain a payment schedule correctly if the first 2 quarters are discounted" in {
-    val firstDiscountedPayment = Payment(new LocalDate(2019, 1, 14), 30.00)
-    val firstFullPricePayment = Payment(new LocalDate(2019, 7, 14), 37.50)
+    val firstDiscountedPayment = Payment(referenceDate, 30.00)
+    val firstFullPricePayment = Payment(referenceDate.plusMonths(6), 37.50)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(3)) ++ payments(firstFullPricePayment, List(3, 6))
     val expected = "£30.00 for 2 quarters, then £37.50 every quarter"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP) == expected)

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -13,13 +13,13 @@ import com.gu.support.workers.Fixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas.SendThankYouEmail
-import com.gu.support.workers.{DirectDebitPaymentMethod, LambdaSpec, Monthly, User}
+import com.gu.support.workers._
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.threadpools.CustomPool.executionContext
 import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.parser._
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, LocalDate}
 
 @IntegrationTest
 class SendThankYouEmailSpec extends LambdaSpec {
@@ -61,6 +61,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
       "A-S00045678",
       Monthly,
       user,
+      PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90))),
       GBP,
       dd,
       SfContactId("0036E00000WK8fDQAT"),

--- a/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -59,7 +59,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
     val user = User("1234", addressToSendTo, "Mickey", "Mouse", UK)
     val ef = DigitalPackEmailFields(
       "A-S00045678",
-      Monthly,
+      Annual,
       user,
       PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90))),
       GBP,


### PR DESCRIPTION
## Why are you doing this?

This PR uses the payment schedule added in https://github.com/guardian/support-workers/pull/168, to provide an accurate description of a user's payment schedule for the thank you email.

[**Trello Card**](https://trello.com/c/BdMnVPuz/1811-thank-you-email-credit-debit-card)

## Changes

* Add helpers to describe pricing based on payment schedule
* Replace some to-dos and hardcoded values in the Digital Pack email with calculated values
* Add unit tests