### PR TITLE
If we have a telephone number when creating a salesforce contact, add it too.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val root = (project in file("."))
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "io.symphonia" % "lambda-logging" % "1.0.1",
       "com.gu" %% "support-internationalisation" % "0.9",
-      "com.gu" %% "support-models" % "0.48",
+      "com.gu" %% "support-models" % "0.49",
       "com.gu" %% "support-config" % "0.17",
       "com.gu" %% "support-services" % "0.1",
       "com.squareup.okhttp3" % "okhttp" % okhttpVersion,

--- a/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -63,7 +63,7 @@ object Salesforce {
     Allow_Membership_Mail__c: Boolean,
     Allow_3rd_Party_Mail__c: Boolean,
     Allow_Guardian_Related_Mail__c: Boolean,
-    Phone: Option[String]
+    Department: Option[String]
   )
 
   trait SalesforceResponse {

--- a/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -29,11 +29,21 @@ object Salesforce {
       mailingCountry: String,
       allowMembershipMail: Boolean,
       allow3rdPartyMail: Boolean,
-      allowGuardianRelatedMail: Boolean
+      allowGuardianRelatedMail: Boolean,
+      telephoneNumber: Option[String]
     ): UpsertData =
       UpsertData(
         NewContact(
-          identityId, email, firstName, lastName, mailingState, mailingCountry, allowMembershipMail, allow3rdPartyMail, allowGuardianRelatedMail
+          identityId,
+          email,
+          firstName,
+          lastName,
+          mailingState,
+          mailingCountry,
+          allowMembershipMail,
+          allow3rdPartyMail,
+          allowGuardianRelatedMail,
+          telephoneNumber
         )
       )
     // scalastyle:on parameter.number
@@ -52,7 +62,8 @@ object Salesforce {
     MailingCountry: String,
     Allow_Membership_Mail__c: Boolean,
     Allow_3rd_Party_Mail__c: Boolean,
-    Allow_Guardian_Related_Mail__c: Boolean
+    Allow_Guardian_Related_Mail__c: Boolean,
+    Phone: Option[String]
   )
 
   trait SalesforceResponse {

--- a/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -63,7 +63,7 @@ object Salesforce {
     Allow_Membership_Mail__c: Boolean,
     Allow_3rd_Party_Mail__c: Boolean,
     Allow_Guardian_Related_Mail__c: Boolean,
-    Department: Option[String]
+    Phone: Option[String]
   )
 
   trait SalesforceResponse {

--- a/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -27,10 +27,10 @@ object Salesforce {
       lastName: String,
       mailingState: Option[String],
       mailingCountry: String,
+      telephoneNumber: Option[String],
       allowMembershipMail: Boolean,
       allow3rdPartyMail: Boolean,
-      allowGuardianRelatedMail: Boolean,
-      telephoneNumber: Option[String]
+      allowGuardianRelatedMail: Boolean
     ): UpsertData =
       UpsertData(
         NewContact(
@@ -40,10 +40,10 @@ object Salesforce {
           lastName,
           mailingState,
           mailingCountry,
+          telephoneNumber,
           allowMembershipMail,
           allow3rdPartyMail,
-          allowGuardianRelatedMail,
-          telephoneNumber
+          allowGuardianRelatedMail
         )
       )
     // scalastyle:on parameter.number
@@ -60,10 +60,10 @@ object Salesforce {
     LastName: String,
     MailingState: Option[String],
     MailingCountry: String,
+    Phone: Option[String],
     Allow_Membership_Mail__c: Boolean,
     Allow_3rd_Party_Mail__c: Boolean,
-    Allow_Guardian_Related_Mail__c: Boolean,
-    Phone: Option[String]
+    Allow_Guardian_Related_Mail__c: Boolean
   )
 
   trait SalesforceResponse {

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -25,7 +25,8 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.country.name,
       state.user.allowMembershipMail,
       state.user.allowThirdPartyMail,
-      state.user.allowGURelatedMail
+      state.user.allowGURelatedMail,
+      state.user.telephoneNumber
     )).map(response =>
       if (response.Success) {
         HandlerResult(getCreateZuoraSubscriptionState(state, response), requestInfo)

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactState, CreateZuoraSubscriptionState] {
 
   override protected def servicesHandler(state: CreateSalesforceContactState, requestInfo: RequestInfo, context: Context, services: Services) = {
-    SafeLogger.debug(s"CreateSalesforceContact state: $state")
+    SafeLogger.info(s"CreateSalesforceContact state: $state")
     services.salesforceService.upsert(UpsertData.create(
       state.user.id,
       state.user.primaryEmailAddress,
@@ -27,14 +27,16 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user.allowThirdPartyMail,
       state.user.allowGURelatedMail,
       state.user.telephoneNumber
-    )).map(response =>
+    )).map {response =>
+      SafeLogger.info(s"response on salesforce contact upsert $response")
       if (response.Success) {
         HandlerResult(getCreateZuoraSubscriptionState(state, response), requestInfo)
       } else {
         val errorMessage = response.ErrorString.getOrElse("No error message returned")
         SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
         throw new SalesforceException(errorMessage)
-      })
+      }
+    }
   }
 
   private def getCreateZuoraSubscriptionState(state: CreateSalesforceContactState, response: SalesforceContactResponse) =

--- a/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -4,6 +4,7 @@ object Fixtures {
   val idId = "9999999"
   val salesforceId = "0036E00000Uc1IhQAJ"
   val email = "yjcysqxfcqqytuzupjc@gu.com"
+  val telephoneNumber = "0123456789"
   val name = "YJCysqXFCqqYtuzuPJc"
   val uk = "UK"
   val us = "US"
@@ -31,6 +32,20 @@ object Fixtures {
         "LastName": "$name",
         "MailingState": "$state",
         "MailingCountry": "$us",
+        "Allow_Membership_Mail__c": $allowMail,
+        "Allow_3rd_Party_Mail__c": $allowMail,
+        "Allow_Guardian_Related_Mail__c": $allowMail
+       }
+      }"""
+  val upsertJsonWithTelephoneNumber =
+    s"""{
+      "newContact": {
+        "IdentityID__c": "$idId",
+        "Email": "$email",
+        "FirstName": "$name",
+        "LastName": "$name",
+        "MailingCountry": "$uk",
+        "Phone": "$telephoneNumber",
         "Allow_Membership_Mail__c": $allowMail,
         "Allow_3rd_Party_Mail__c": $allowMail,
         "Allow_Guardian_Related_Mail__c": $allowMail

--- a/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -59,4 +59,14 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
       response.ContactRecord.Id should be(salesforceId)
     }
   }
+
+  "SalesforceService" should "be able to upsert a customer that has an optional field" in {
+    val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
+    val upsertData = UpsertData.create(idId, email, name, name, None, uk, Some(telephoneNumber), allowMail, allowMail, allowMail)
+
+    service.upsert(upsertData).map { response: SalesforceContactResponse =>
+      response.Success should be(true)
+      response.ContactRecord.Id should be(salesforceId)
+    }
+  }
 }

--- a/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -52,7 +52,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "SalesforceService" should "be able to upsert a customer" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val upsertData = UpsertData.create(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, None)
+    val upsertData = UpsertData.create(idId, email, name, name, None, uk, None, allowMail, allowMail, allowMail)
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
       response.Success should be(true)

--- a/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -52,7 +52,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "SalesforceService" should "be able to upsert a customer" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val upsertData = UpsertData.create(idId, email, name, name, None, uk, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, None)
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
       response.Success should be(true)

--- a/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -11,12 +11,12 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
   "UpsertData" should "serialise to correct UK json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail))
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, Some("07987654321")))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct US json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, Some(state), us, allowMail, allowMail, allowMail))
+    val upsertData = UpsertData(NewContact(idId, email, name, name, Some(state), us, allowMail, allowMail, allowMail, None))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
   }
 

--- a/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
   "UpsertData" should "serialise to correct UK json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, Some("07987654321")))
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, None))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 

--- a/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -11,13 +11,18 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
   "UpsertData" should "serialise to correct UK json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, allowMail, allowMail, allowMail, None))
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, None, allowMail, allowMail, allowMail))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct US json" in {
-    val upsertData = UpsertData(NewContact(idId, email, name, name, Some(state), us, allowMail, allowMail, allowMail, None))
+    val upsertData = UpsertData(NewContact(idId, email, name, name, Some(state), us, None, allowMail, allowMail, allowMail))
     upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
+  }
+
+  "UpsertData" should "serialise to correct json when telephoneNumber provided" in {
+    val upsertData = UpsertData(NewContact(idId, email, name, name, None, uk, Some(telephoneNumber), allowMail, allowMail, allowMail))
+    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithTelephoneNumber).right.get.noSpaces)
   }
 
   "Authentication" should "deserialize correctly" in {

--- a/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -25,7 +25,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
 
   it should "throw a SalesforceAuthenticationErrorResponse if the authentication fails" in {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
-    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail, None)
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     assertThrows[SalesforceAuthenticationErrorResponse] {
@@ -39,7 +39,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
       override def addAuthenticationToRequest(auth: Authentication, req: Request.Builder): Request.Builder =
         req.url(s"${auth.instance_url}/$upsertEndpoint") //We still need to set the base url
     }
-    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail)
+    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail, None)
 
     recoverToSucceededIf[SalesforceErrorResponse] {
       service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))

--- a/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -25,7 +25,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
 
   it should "throw a SalesforceAuthenticationErrorResponse if the authentication fails" in {
     val invalidConfig = SalesforceConfig("", "https://test.salesforce.com", "", "", "", "", "")
-    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail, None)
+    val upsertData = UpsertData.create(idId, email, name, name, None, us, None, allowMail, allowMail, allowMail)
     val service = new SalesforceService(invalidConfig, configurableFutureRunner(10.seconds))
 
     assertThrows[SalesforceAuthenticationErrorResponse] {
@@ -39,7 +39,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
       override def addAuthenticationToRequest(auth: Authentication, req: Request.Builder): Request.Builder =
         req.url(s"${auth.instance_url}/$upsertEndpoint") //We still need to set the base url
     }
-    val upsertData = UpsertData.create(idId, email, name, name, None, us, allowMail, allowMail, allowMail, None)
+    val upsertData = UpsertData.create(idId, email, name, name, None, us, None, allowMail, allowMail, allowMail)
 
     recoverToSucceededIf[SalesforceErrorResponse] {
       service.upsert(upsertData).map(response => SafeLogger.info(s"Got a response: $response"))


### PR DESCRIPTION
## Why are you doing this?
We are asking for telephone number in the new digital pack checkout. When we make a request to create a new digital pack, if the user gives us their telephone number, we will include it in that request. We should make sure that telephone number is saved in salesforce, so that we can use it to contact them regarding their subscription if relevant. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/zcaNKssy/2156-make-sure-telephone-number-if-provided-makes-its-way-to-salesforce)

## Changes

* Use new version of support-models https://github.com/guardian/support-libraries/pull/16
* When we create a new salesforce contact, if we have a telephone number for the user, then we add this too the contact too. 
