### PR TITLE
send address details in the request to zuora to create a subscription

### DIFF
--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -122,6 +122,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       address1 = state.user.billingAddress.lineOne,
       address2 = state.user.billingAddress.lineTwo,
       city = state.user.billingAddress.city,
+      postalCode = state.user.billingAddress.postCode,
       country = state.user.billingAddress.country,
       state = state.user.billingAddress.state
     )

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -119,6 +119,9 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       firstName = state.user.firstName,
       lastName = state.user.lastName,
       workEmail = state.user.primaryEmailAddress,
+      address1 = state.user.billingAddress.lineOne,
+      address2 = state.user.billingAddress.lineTwo,
+      city = state.user.billingAddress.city,
       country = state.user.billingAddress.country,
       state = state.user.billingAddress.state
     )


### PR DESCRIPTION
## Why are you doing this?
As of https://github.com/guardian/support-workers/pull/176/files, we send address data to Salesforce when creating a digital pack subscription or recurring contribution via `support-workers`.

Address changes do get synced from Salesforce to Zuora, but the details when a new contact is created do not, so we send the address details in the billToContact when making the [subscribe request to Zuora](https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe)

The checkout on subscribe.theguardian also does this. See: https://github.com/guardian/membership-common/blob/master/src/main/scala/com/gu/zuora/soap/writers/Command.scala#L245

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9e2k1vw4/2221-send-billing-address-data-to-sf)

## Changes

* Send address details in the billToContact block of the subscribe request to Zuora
