### PR TITLE
When creating digital pack subscriptions, get rate plan id from the Product mapping

### DIFF
--- a/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers.exceptions
 import java.net.{SocketException, SocketTimeoutException}
 
 import com.amazonaws.services.kms.model._
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.sqs.model.{AmazonSQSException, InvalidMessageContentsException, QueueDoesNotExistException}
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.helpers.WebServiceHelperError
@@ -41,6 +42,13 @@ object RetryImplicits {
     def asRetryException: RetryException = throwable match {
       case e: InvalidMessageContentsException => new RetryNone(message = e.getMessage, cause = throwable)
       case e: QueueDoesNotExistException => new RetryLimited(message = e.getMessage, cause = throwable)
+    }
+  }
+
+  implicit class ZuoraCatalogueConversions(val throwable: ZuoraCatalogException) {
+    def asRetryException: RetryException = throwable match {
+      case e: CatalogDataNotFound => new RetryNone(message = e.getMessage, cause = throwable)
+      case e: ZuoraCatalogException => new RetryNone(message = e.getMessage, cause = throwable)
     }
   }
 

--- a/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -45,7 +45,7 @@ object RetryImplicits {
     }
   }
 
-  implicit class ZuoraCatalogueConversions(val throwable: CatalogDataNotFoundException) {
+  implicit class ZuoraCatalogConversions(val throwable: CatalogDataNotFoundException) {
     def asRetryException: RetryException = new RetryNone(message = throwable.getMessage, cause = throwable)
   }
 

--- a/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -45,11 +45,8 @@ object RetryImplicits {
     }
   }
 
-  implicit class ZuoraCatalogueConversions(val throwable: ZuoraCatalogException) {
-    def asRetryException: RetryException = throwable match {
-      case e: CatalogDataNotFound => new RetryNone(message = e.getMessage, cause = throwable)
-      case e: ZuoraCatalogException => new RetryNone(message = e.getMessage, cause = throwable)
-    }
+  implicit class ZuoraCatalogueConversions(val throwable: CatalogDataNotFoundException) {
+    def asRetryException: RetryException = new RetryNone(message = throwable.getMessage, cause = throwable)
   }
 
   implicit class OphanServiceErrorConversions(val error: AnalyticsServiceError) {

--- a/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
@@ -1,0 +1,5 @@
+package com.gu.support.workers.exceptions
+
+class ZuoraCatalogException(message: String = "", cause: Throwable = None.orNull) extends Throwable(message, cause)
+
+class CatalogDataNotFound(message: String = "", cause: Throwable = None.orNull) extends ZuoraCatalogException(message, cause)

--- a/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
@@ -1,5 +1,3 @@
 package com.gu.support.workers.exceptions
 
-class ZuoraCatalogException(message: String = "", cause: Throwable = None.orNull) extends Throwable(message, cause)
-
-class CatalogDataNotFound(message: String = "", cause: Throwable = None.orNull) extends ZuoraCatalogException(message, cause)
+class CatalogDataNotFoundException(message: String = "", cause: Throwable = None.orNull) extends Throwable(message, cause)

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
+import com.gu.support.catalog.CatalogService
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.PromotionService
 import com.gu.support.workers.states.{CreateZuoraSubscriptionState, SendThankYouEmailState}

--- a/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.catalog.CatalogService
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.PromotionService
 import com.gu.support.workers.states.{CreateZuoraSubscriptionState, SendThankYouEmailState}

--- a/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -1,18 +1,39 @@
 package com.gu.zuora
 
+import com.gu.config.Configuration
 import com.gu.i18n.Country
-import com.gu.support.catalog.ProductRatePlanId
-import com.gu.support.config.ZuoraConfig
+import com.gu.support.catalog
+import com.gu.support.catalog.{Product, ProductRatePlan, ProductRatePlanId}
+import com.gu.support.config.{TouchPointEnvironments, ZuoraConfig}
 import com.gu.support.promotions.{PromoCode, PromotionService}
-import com.gu.support.workers.{Contribution, DigitalPack}
+import com.gu.support.workers.exceptions.CatalogDataNotFound
+import com.gu.support.workers.{Contribution, DigitalPack, ProductType}
 import com.gu.support.zuora.api._
 import org.joda.time.{DateTimeZone, LocalDate}
 
+import scala.util.{Failure, Success, Try}
+
 object ProductSubscriptionBuilders {
+
+  def getProductRatePlanId[PT <: ProductType, P <: Product](product: P, productType: PT): ProductRatePlanId = {
+    val touchpointEnvironment = TouchPointEnvironments.fromStage(Configuration.stage)
+    def getRatePlans[T <: Product](product: T): Seq[ProductRatePlan[Product]] = product.ratePlans.getOrElse(touchpointEnvironment, Nil)
+
+    val ratePlans: Seq[ProductRatePlan[Product]] = getRatePlans(catalog.DigitalPack)
+
+    val maybeProductRatePlanId: Option[ProductRatePlanId] = ratePlans.find(p => p.billingPeriod == productType.billingPeriod) map (_.id)
+
+    Try(maybeProductRatePlanId.get) match {
+      case Success(value) => value
+      case Failure(e) => throw new CatalogDataNotFound(s"RatePlanId not found for ${productType.toString}", e)
+    }
+  }
 
   implicit class ContributionSubscriptionBuilder(val contribution: Contribution) extends ProductSubscriptionBuilder {
     def build(config: ZuoraConfig): SubscriptionData = {
       val contributionConfig = config.contributionConfig(contribution.billingPeriod)
+      val productRatePlanId = getProductRatePlanId(catalog.Contribution, contribution)
+
       buildProductSubscription(
         contributionConfig.productRatePlanId,
         List(
@@ -26,12 +47,13 @@ object ProductSubscriptionBuilders {
 
   implicit class DigitalPackSubscriptionBuilder(val digitalPack: DigitalPack) extends ProductSubscriptionBuilder {
     def build(config: ZuoraConfig, country: Country, maybePromoCode: Option[PromoCode], promotionService: PromotionService): SubscriptionData = {
+
       val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
       val contractAcceptanceDate = contractEffectiveDate
         .plusDays(config.digitalPack.defaultFreeTrialPeriod)
         .plusDays(config.digitalPack.paymentGracePeriod)
 
-      val productRatePlanId = config.digitalPackRatePlan(digitalPack.billingPeriod)
+      val productRatePlanId = getProductRatePlanId(catalog.DigitalPack, digitalPack)
 
       val subscriptionData = buildProductSubscription(
         productRatePlanId,
@@ -42,6 +64,7 @@ object ProductSubscriptionBuilders {
       maybePromoCode
         .map(promotionService.applyPromotion(_, country, productRatePlanId, subscriptionData, isRenewal = false))
         .getOrElse(subscriptionData)
+
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?
Now that there is a mapping that provides RatePlanIds here:
https://github.com/guardian/support-libraries/blob/master/support-models/src/main/scala/com/gu/support/catalog/Product.scala

We should get the RatePlanIds for digital pack from that mapping instead, and then it doesn't need to be maintained in `support-config`.

Then we can also do the same for print products. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/ofdmiV3O/2253-add-paper-product-types-to-support-models-config-to-support-config)

## Changes

* Get mapping of ratePlanIds from Product when a ratePlanId is needed to create a digital pack
