### PR TITLE
Revert "When creating digital pack subscriptions, get rate plan id from the Product mapping"

### DIFF
--- a/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -3,7 +3,6 @@ package com.gu.support.workers.exceptions
 import java.net.{SocketException, SocketTimeoutException}
 
 import com.amazonaws.services.kms.model._
-import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.sqs.model.{AmazonSQSException, InvalidMessageContentsException, QueueDoesNotExistException}
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.helpers.WebServiceHelperError
@@ -43,10 +42,6 @@ object RetryImplicits {
       case e: InvalidMessageContentsException => new RetryNone(message = e.getMessage, cause = throwable)
       case e: QueueDoesNotExistException => new RetryLimited(message = e.getMessage, cause = throwable)
     }
-  }
-
-  implicit class ZuoraCatalogConversions(val throwable: CatalogDataNotFoundException) {
-    def asRetryException: RetryException = new RetryNone(message = throwable.getMessage, cause = throwable)
   }
 
   implicit class OphanServiceErrorConversions(val error: AnalyticsServiceError) {

--- a/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
+++ b/src/main/scala/com/gu/support/workers/exceptions/ZuoraCatalogException.scala
@@ -1,3 +1,0 @@
-package com.gu.support.workers.exceptions
-
-class CatalogDataNotFoundException(message: String = "", cause: Throwable = None.orNull) extends Throwable(message, cause)

--- a/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -1,33 +1,14 @@
 package com.gu.zuora
 
-import com.gu.config.Configuration
 import com.gu.i18n.Country
-import com.gu.support.catalog
-import com.gu.support.catalog.{Product, ProductRatePlan, ProductRatePlanId}
-import com.gu.support.config.{TouchPointEnvironments, ZuoraConfig}
+import com.gu.support.catalog.ProductRatePlanId
+import com.gu.support.config.ZuoraConfig
 import com.gu.support.promotions.{PromoCode, PromotionService}
-import com.gu.support.workers.exceptions.CatalogDataNotFoundException
-import com.gu.support.workers.{Contribution, DigitalPack, ProductType}
+import com.gu.support.workers.{Contribution, DigitalPack}
 import com.gu.support.zuora.api._
 import org.joda.time.{DateTimeZone, LocalDate}
 
-import scala.util.{Failure, Success, Try}
-
 object ProductSubscriptionBuilders {
-
-  def getProductRatePlanId[PT <: ProductType, P <: Product](product: P, productType: PT): ProductRatePlanId = {
-    val touchpointEnvironment = TouchPointEnvironments.fromStage(Configuration.stage)
-    def getRatePlans[T <: Product](product: T): Seq[ProductRatePlan[Product]] = product.ratePlans.getOrElse(touchpointEnvironment, Nil)
-
-    val ratePlans: Seq[ProductRatePlan[Product]] = getRatePlans(catalog.DigitalPack)
-
-    val maybeProductRatePlanId: Option[ProductRatePlanId] = ratePlans.find(p => p.billingPeriod == productType.billingPeriod) map (_.id)
-
-    Try(maybeProductRatePlanId.get) match {
-      case Success(value) => value
-      case Failure(e) => throw new CatalogDataNotFoundException(s"RatePlanId not found for ${productType.toString}", e)
-    }
-  }
 
   implicit class ContributionSubscriptionBuilder(val contribution: Contribution) extends ProductSubscriptionBuilder {
     def build(config: ZuoraConfig): SubscriptionData = {
@@ -45,19 +26,19 @@ object ProductSubscriptionBuilders {
 
   implicit class DigitalPackSubscriptionBuilder(val digitalPack: DigitalPack) extends ProductSubscriptionBuilder {
     def build(config: ZuoraConfig, country: Country, maybePromoCode: Option[PromoCode], promotionService: PromotionService): SubscriptionData = {
-
       val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
       val contractAcceptanceDate = contractEffectiveDate
         .plusDays(config.digitalPack.defaultFreeTrialPeriod)
         .plusDays(config.digitalPack.paymentGracePeriod)
 
-      val productRatePlanId = getProductRatePlanId(catalog.DigitalPack, digitalPack)
+      val productRatePlanId = config.digitalPackRatePlan(digitalPack.billingPeriod)
 
       val subscriptionData = buildProductSubscription(
         productRatePlanId,
         contractAcceptanceDate = contractAcceptanceDate,
         contractEffectiveDate = contractEffectiveDate
       )
+
       maybePromoCode
         .map(promotionService.applyPromotion(_, country, productRatePlanId, subscriptionData, isRenewal = false))
         .getOrElse(subscriptionData)


### PR DESCRIPTION
Reverts guardian/support-workers#180